### PR TITLE
ログイン状態でないと掲示板ハブ・掲示板にアクセスできないように

### DIFF
--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -1,21 +1,23 @@
-<!DOCTYPE html>
-<html lang="ja">
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            掲示板ハブ
+        </h2>
+    </x-slot>
 
-<head>
-	<meta cahrset="UTF-8">
-	<title>掲示板ハブ</title>
-</head>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
 
-<body>
-	<div>
-		<h1>HxSコンピュータ部　掲示板</h1>
-	</div>
-
-	<div>
-		@foreach($tables as $tableName)
-			<li><a href="keiziban?table%5B%5D={{$tableName}}">{{$tableName}}</a></li>
-		@endforeach
-	</div>	
-</body>
-
-</html>
+			<!-- my area begin -->
+				<div>
+					@foreach($tables as $tableName)
+						<li><a href="keiziban?table%5B%5D={{$tableName}}">{{$tableName}}</a></li>
+					@endforeach
+				</div>
+			<!-- my area begin -->
+			
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            掲示板ハブ
+            {{$tableName}}
         </h2>
     </x-slot>
 
@@ -19,9 +19,7 @@
 					</script>
 				</div>
 
-				<div>
-					<h1>{{$tableName}}</h1>
-					
+				<div>					
 					<a href="{{ url('/hub') }}">戻る</a>
 					<br><br>
 					

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -1,41 +1,50 @@
-<!DOCTYPE html>
-<html lang="ja">
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            掲示板ハブ
+        </h2>
+    </x-slot>
 
-<head>
-	<meta charset="utf-8">
-	<meta name="csrf-token" content="{{ csrf_token() }}">
-	<script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
-	<script>
-		const url = "{{$url}}";
-		const table = "{{$tableName}}";
-	</script>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
 
-	<title>掲示板-{{$tableName}}</title>
-</head>
+			<!-- my area begin -->
+				<div>
+					<meta name="csrf-token" content="{{ csrf_token() }}">
+					<script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
+					<script>
+						const url = "{{$url}}";
+						const table = "{{$tableName}}";
+					</script>
+				</div>
 
-<body>
-	<h1>{{$tableName}}</h1>
+				<div>
+					<h1>{{$tableName}}</h1>
+					
+					<a href="{{ url('/hub') }}">戻る</a>
+					<br><br>
+					
+					<div>
+						<form id="sendMessage">
+							<p>名前</p>
+							<input type="text" name="name">
+							<p>コメント</p>
+							<textarea name="message"></textarea>
+						</form>
+						<button id="sendMessageBtn">書き込み</button>
+						<script src="{{ mix('js/Send_Row.js') }}"></script>
+					</div>
+					
+					<br><br><br>
+					
+					<div id="displayArea">
+						<script src="{{ mix('/js/Get_allRow.js') }}"></script>
+					</div>
+				</div>
+			<!-- my area end -->
 
-	<a href="{{ url('/hub') }}">戻る</a>
-
-	<br>
-	<div>
-		<form id="sendMessage">
-			<p>名前</p>
-			<input type="text" name="name">
-			<p>コメント</p>
-			<textarea name="message"></textarea>
-		</form>
-		<button id="sendMessageBtn">書き込み</button>
-		<script src="{{ mix('js/Send_Row.js') }}"></script>
-	</div>
-	
-	<br><br><br>
-	
-	<div id="displayArea">
-	<script src="{{ mix('/js/Get_allRow.js') }}"></script>
-	</div>
-
-</body>
-
-</html>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -15,6 +15,9 @@
                     <x-jet-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-jet-nav-link>
+                    <x-jet-nav-link href="{{ route('hub') }}" :active="request()->routeIs('hub')">
+                        掲示板ハブ
+                    </x-jet-nav-link>
                 </div>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,8 +15,6 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function() {
 	return view('welcome');
 });
-Route::get('/hub2', "App\Http\Controllers\showTablesCTL");
-Route::get('/keiziban', "App\Http\Controllers\keizibanCTL");
 
 Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
 Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
@@ -37,4 +35,12 @@ Route::middleware([
     'verified'
 ])->group(function () {
     Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
+});
+
+Route::middleware([
+    'auth:sanctum',
+    config('jetstream.auth_session'),
+    'verified'
+])->group(function () {
+    Route::get('/keiziban', 'App\Http\Controllers\keizibanCTL')->name('keiziban');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function() {
 	return view('welcome');
 });
-Route::get('/hub', "App\Http\Controllers\showTablesCTL");
+Route::get('/hub2', "App\Http\Controllers\showTablesCTL");
 Route::get('/keiziban', "App\Http\Controllers\keizibanCTL");
 
 Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
@@ -29,4 +29,12 @@ Route::middleware([
     Route::get('/dashboard', function () {
         return view('dashboard');
     })->name('dashboard');
+});
+
+Route::middleware([
+    'auth:sanctum',
+    config('jetstream.auth_session'),
+    'verified'
+])->group(function () {
+    Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
 });


### PR DESCRIPTION
## 関連

- ログイン状態でのみ，掲示板にアクセスできるように（team discussions）

## なぜこの変更をするのか

- 掲示板に誰が何を書き込んだのか，（管理者が）把握できるようにするため

## やったこと

- ログイン状態でないと掲示板ハブ・掲示板にアクセスできないように
- ページ内のタブでダッシュボードと掲示板（ハブ）の切り替えができるように

---
![](https://user-images.githubusercontent.com/90523045/166148219-5cbf356a-3f14-4fa4-b16d-e05d634bdaf1.png)
---
![](https://user-images.githubusercontent.com/90523045/166148218-95e47312-0155-4f9c-af79-d0da1b88006d.png)
---
![](https://user-images.githubusercontent.com/90523045/166148217-9ddb8dda-6fde-4ae5-abcf-fc5be38a6b91.png)
---

## やらないこと

- h1タグ等が使えないようですが，そこに関するデザインの変更は行いません
- 誰が何を書き込んだのかを保存する処理はまだ行っておりません（team discussionに追記）

## できるようになること（ユーザ目線）

- ログイン後，すぐに掲示板を利用できるようになります

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 掲示板ハブのリンクは正常に動作するか
- 掲示板への書き込み・内容の取得は正常に動作するか
両者ともに正常に動作しました

- ログインしていない状態で掲示板（ハブ）にアクセスできるかどうか
アクセスできませんでした（正常な動作）

## 備考

- 無し