### PR TITLE
新規登録のメール入力エラーを解消

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -22,14 +22,14 @@ class CreateNewUser implements CreatesNewUsers
     {
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
         return User::create([
             'name' => $input['name'],
-            'email' => strstr($input['email'], '@', true) . "@st.oit.ac.jp",
+            'email' => $input['email'] . "@st.oit.ac.jp",
             'password' => Hash::make($input['password']),
         ]);
     }

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -20,16 +20,19 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input)
     {
+        $email = $input['email'] . "@st.oit.ac.jp";
+        $input['email'] = strstr($email, '@', true) . "@st.oit.ac.jp";
+
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
         return User::create([
             'name' => $input['name'],
-            'email' => $input['email'] . "@st.oit.ac.jp",
+            'email' => $input['email'],
             'password' => Hash::make($input['password']),
         ]);
     }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -15,8 +15,8 @@
             </div>
 
             <div class="mt-4">
-                <x-jet-label for="email" value="{{ __('Email') }} ※@以降の文字列は@st.oit.ac.jpに置き換えられます" />
-                <x-jet-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required />
+                <x-jet-label for="email" value="学生番号（e1~）確認メールが送信されます" />
+                <x-jet-input id="email" class="block mt-1 w-full" type="text" name="email" :value="old('email')" required />
             </div>
 
             <div class="mt-4">


### PR DESCRIPTION
## 関連

- #13 
- #12 
- #10 

## なぜこの変更をするのか

- バグ解決のため
- 入力の手間を解消するため

## やったこと

- 新規登録のメール入力欄で@以降の入力を不要に
- @以降を無効化する事でドメイン名のエラーを解消

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 新規登録時に@以降の入力が不要になる（ログイン時は@以降必要）

## できなくなること（ユーザ目線）

- 無し

## 動作確認

同じアカウントが登録されている状態・されていない状態共に，メール（学生番号）入力欄で以下のパターンを試しました

- アカウント名
- アカウント名@
- アカウント名@ドメイン名

すべての状態で正しく動作しました．

- 未登録であればドメイン名を追加してアカウント追加
- 登録済みであれば「登録されています」のメッセージを表示

## その他

- 無し
