### PR TITLE
掲示板に書き込みした際に表示される名前をアカウントのユーザ名に固定する

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -18,7 +18,7 @@ class jQuery_ajax extends Controller {
 		$send = new Send;
 		$send->insertComment(
 			$request->post('table'), 
-			$request->post('name'), 
+			$request->user()->name, 
 			$request->post('message')
 		);
 		return null;

--- a/app/Http/Controllers/keizibanCTL.php
+++ b/app/Http/Controllers/keizibanCTL.php
@@ -11,6 +11,7 @@ class keizibanCTL extends Controller {
 		$stmt = $get->allRow($request->get('table')[0]);
 
 		$response['tableName'] = $request->get('table')[0];
+		$response['username'] = $request->user()->name;
 		$response['url'] = url('/');
 		$response['allRow'] = $stmt;
 		return view('keiziban', $response);

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1262,6 +1262,9 @@ select {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.break-all {
+  word-break: break-all;
+}
 .rounded-md {
   border-radius: 0.375rem;
 }

--- a/public/js/Get_allRow.js
+++ b/public/js/Get_allRow.js
@@ -13,9 +13,6 @@ setInterval(function () {
   $.ajax({
     type: "POST",
     url: url + "/jQuery.ajax/getRow",
-    data: {
-      'table': table
-    },
     dataType: "json"
   }).done(function (data) {
     // 成功時

--- a/public/js/Send_Row.js
+++ b/public/js/Send_Row.js
@@ -5,9 +5,6 @@ var __webpack_exports__ = {};
   \**********************************/
 $('#sendMessageBtn').click(function () {
   var formElm = document.getElementById("sendMessage");
-  var name = formElm.name.value;
-  var message = formElm.message.value;
-  formElm.name.value = '';
   formElm.message.value = '';
   $.ajaxSetup({
     headers: {
@@ -16,12 +13,7 @@ $('#sendMessageBtn').click(function () {
   });
   $.ajax({
     type: "POST",
-    url: url + "/jQuery.ajax/sendRow",
-    data: {
-      "table": table,
-      "name": name,
-      "message": message
-    }
+    url: url + "/jQuery.ajax/sendRow"
   }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
     console.log(XMLHttpRequest.status);
     console.log(textStatus);

--- a/resources/js/Get_allRow.js
+++ b/resources/js/Get_allRow.js
@@ -10,7 +10,6 @@ setInterval(function(){
     $.ajax({
         type: "POST",
         url: url + "/jQuery.ajax/getRow",
-        data: { 'table': table },
         dataType: "json",
     }).done(function (data) { // 成功時
         displayArea.innerHTML = "<br>";

--- a/resources/js/Send_Row.js
+++ b/resources/js/Send_Row.js
@@ -1,8 +1,5 @@
 $('#sendMessageBtn').click(function () {
 	const formElm = document.getElementById("sendMessage");
-	const name = formElm.name.value;
-	const message = formElm.message.value;
-	formElm.name.value = '';
 	formElm.message.value = '';
 
 	$.ajaxSetup({
@@ -14,11 +11,6 @@ $('#sendMessageBtn').click(function () {
 	$.ajax({
 		type: "POST",
 		url: url + "/jQuery.ajax/sendRow",
-		data: {
-			"table": table,
-			"name": name,
-			"message": message
-		},
 	}).done(function () {
 	}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
 		console.log(XMLHttpRequest.status);

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -25,8 +25,8 @@
 					
 					<div>
 						<form id="sendMessage">
-							<p>名前</p>
-							<input type="text" name="name">
+							<p>{{$username}}</p>
+							<br>
 							<p>コメント</p>
 							<textarea name="message"></textarea>
 						</form>


### PR DESCRIPTION
## 関連

- #9 
- #16 

## なぜこの変更をするのか

- Issueで説明が十分なため無し

## やったこと

- テーブルに登録される名前をログインしているユーザ名に変更
- 不要だった箇所の削除（`public/js/Get_allRow.js`, `public/js/Sned_Row.js`）
必要だと思っていたJQuery.ajaxでの値渡しが不要だったので該当箇所の削除

## やらないこと

- ユーザ名の重複登録の解決
あくまで表示される名前をアカウントのユーザ名に固定することであるため，ここでは解決に取り組みません

## できるようになること（ユーザ目線）

- 掲示板への書き込みの際に，一々ユーザ名を入力しなくても良くなる

## できなくなること（ユーザ目線）

- アカウントとは異なるユーザ名での書き込みができなくなる

## 動作確認

- 掲示板ページに移動し，名前の入寮欄が無いことを確認しました
- 掲示板に書き込み，ログインしているユーザ名が表示されることを確認しました
- 同じユーザ名のアカウントの場合，書き込んだユーザの判断ができなくなってしまうようです

## その他

Laravel以外ではjQuery.ajaxでのデータ渡しには削除前の方法を用いていたのですが，Laravelでは$requestを利用しているので，勝手が異なるようです．$requestの中身に何が入っているのかは未確認です
