### PR TITLE
アカウントのユーザ名に一意性を持たせる

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -24,7 +24,7 @@ class CreateNewUser implements CreatesNewUsers
         $input['email'] = strstr($email, '@', true) . "@st.oit.ac.jp";
 
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', 'unique:users'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -19,7 +19,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     public function update($user, array $input)
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', 'unique:users'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
             'photo' => ['nullable', 'mimes:jpg,jpeg,png', 'max:1024'],
         ])->validateWithBag('updateProfileInformation');


### PR DESCRIPTION
## 関連

- #16 

## なぜこの変更をするのか

- Issueの補足は特にありません

## やったこと

- 新規登録時のユーザ名にユニーク属性を追加
- 更新時のユーザ名にユニーク属性を追加

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- ユーザ名の重複登録ができなくなる（正常な動作）

## 動作確認

- テーブルに存在するユーザ名・テーブルに存在しないメールアドレスで新規登録を行う
- テーブルに存在するユーザ名で更新処理を実行する

両者ともにメッセージが表示され，登録・更新は実行されませんでした

## その他

ユーニーク属性を付ける際，`unique`だけではエラーが表示され，`:users`を付けると正常に動作した．`:users`の意味がよく分かりません．おそらくはテーブル名のことを言っているのかな？
