### PR TITLE
大学アカウント以外のメールアドレスに更新するのを防ぐ

### DIFF
--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -575,7 +575,7 @@
     "Update :resource: :title": "Update :resource: :title",
     "Update attached :resource: :title": "Update attached :resource: :title",
     "Update Password": "パスワード更新",
-    "Update your account's profile information and email address.": "プロフィール情報とメールアドレスを更新する。",
+    "Update your account's profile information and email address.": "プロフィール情報を更新する。",
     "Uruguay": "Uruguay",
     "Use a recovery code": "リカバリーコードを使用する",
     "Use an authentication code": "認証コードを使用する",
@@ -614,5 +614,10 @@
     "You may not leave a team that you created.": "自身が作成したチームを離れることはできません。",
     "Your email address is not verified.": "Your email address is not verified.",
     "Zambia": "Zambia",
-    "Zimbabwe": "Zimbabwe"
+    "Zimbabwe": "Zimbabwe",
+
+    "Email register": "学生番号（e1~）確認メールが送信されます", 
+    "Forum Hub": "掲示板ハブ",
+    "Go hub": "掲示板ハブへ戻る", 
+    "Write forum": "書き込み"
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -15,7 +15,7 @@
             </div>
 
             <div class="mt-4">
-                <x-jet-label for="email" value="学生番号（e1~）確認メールが送信されます" />
+                <x-jet-label for="email" value="{{__('Email register')}}" />
                 <x-jet-input id="email" class="block mt-1 w-full" type="text" name="email" :value="old('email')" required />
             </div>
 

--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            掲示板ハブ
+            {{__('Forum Hub')}}
         </h2>
     </x-slot>
 

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -20,7 +20,7 @@
 				</div>
 
 				<div>					
-					<a href="{{ url('/hub') }}">戻る</a>
+					<a href="{{ url('/hub') }}">{{__('Go hub')}}</a>
 					<br><br>
 					
 					<div>
@@ -30,7 +30,7 @@
 							<p>コメント</p>
 							<textarea name="message"></textarea>
 						</form>
-						<button id="sendMessageBtn">書き込み</button>
+						<button id="sendMessageBtn">{{__('Write forum')}}</button>
 						<script src="{{ mix('js/Send_Row.js') }}"></script>
 					</div>
 					

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -16,7 +16,7 @@
                         {{ __('Dashboard') }}
                     </x-jet-nav-link>
                     <x-jet-nav-link href="{{ route('hub') }}" :active="request()->routeIs('hub')">
-                        掲示板ハブ
+                        {{__('Forum Hub')}}
                     </x-jet-nav-link>
                 </div>
             </div>

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -59,12 +59,13 @@
             <x-jet-input-error for="name" class="mt-2" />
         </div>
 
-        <!-- Email -->
+        <!-- Email 
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="email" value="{{ __('Email') }}" />
             <x-jet-input id="email" type="email" class="mt-1 block w-full" wire:model.defer="state.email" />
             <x-jet-input-error for="email" class="mt-2" />
         </div>
+        -->
     </x-slot>
 
     <x-slot name="actions">


### PR DESCRIPTION
## 関連

- #15 

## なぜこの変更をするのか

- Issueの他に補足説明は特にありません

## やったこと

- メールアドレスの更新用フォームの削除
- それに関するメッセージの編集
- （する必要があるかは分からないが）多言語化に対応できる様にjs.jsonなどの調整

## やらないこと

- メールアドレスを更新する処理を削除する

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- メールアドレスの更新ができなくなる（正常な動作）

## 動作確認

- プロフィール欄の更新用フォームが削除されている事を確認しました

## その他

メールアドレス更新用の処理がよく分からなかったので，削除するわけにはいかず，そのままになっている．そのため，何らかの方法でその処理を利用される危険性がある