### PR TITLE
掲示板初回読み込みの時間を短縮する

### DIFF
--- a/public/js/Get_allRow.js
+++ b/public/js/Get_allRow.js
@@ -3,7 +3,10 @@ var __webpack_exports__ = {};
 /*!************************************!*\
   !*** ./resources/js/Get_allRow.js ***!
   \************************************/
-setInterval(function () {
+reload();
+setInterval(reload(), 1000);
+
+function reload() {
   var displayArea = document.getElementById("displayArea");
   $.ajaxSetup({
     headers: {
@@ -30,6 +33,6 @@ setInterval(function () {
     console.log(textStatus);
     console.log(errorThrown.message);
   });
-}, 1000);
+}
 /******/ })()
 ;

--- a/resources/js/Get_allRow.js
+++ b/resources/js/Get_allRow.js
@@ -1,4 +1,7 @@
-setInterval(function(){
+reload();
+setInterval(reload(), 1000);
+
+function reload(){
     var displayArea = document.getElementById("displayArea");
 
     $.ajaxSetup({
@@ -23,4 +26,4 @@ setInterval(function(){
         console.log(textStatus);
         console.log(errorThrown.message);
     });
-}, 1000);
+}


### PR DESCRIPTION
## 関連

- #6

## なぜこの変更をするのか

- Issueで十分なので補足説明はありません

## やったこと

- 繰り返し実行する部分を関数化し，始めに実行する部分と繰り返し実行する部分に分割

## やらないこと

無し

## できるようになること（ユーザ目線）

- 掲示板初回読み込み時の間を減らす事ができる様になる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 全ての掲示板の初回読み込み速度が素早くなっている事を確認した

## その他

-  無し
