### PR TITLE
掲示板に改行機能追加

### DIFF
--- a/app/Models/Send.php
+++ b/app/Models/Send.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\DB;
 
 class Send extends Model {
 	public function insertComment($table, $name, $message) {
+		$message = str_replace("\n", "<br>", $message);
 		DB::connection('mysql_keiziban')->insert(
 			"INSERT INTO $table(no, name, message, time) VALUES(NULL, :name, :message, NOW())", 
 			[$name, $message]);


### PR DESCRIPTION
## 関連

- #7 

## なぜこの変更をするのか

- 無し

## やったこと

- 掲示板の入力文字列から，改行コードをを書き換えて表示するときに改行されるように

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 掲示板書き込みの改行ができる様になる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 実際に掲示板に改行ありの文字列を入力してみて，改行されることを確認した

## その他

- 無し
