### PR TITLE
スレッド作成機能の追加

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Get;
 use App\Models\Send;
+use App\Models\create_thread;
 
 class jQuery_ajax extends Controller {
 	public function get_allRow(Request $request) {
@@ -21,6 +22,12 @@ class jQuery_ajax extends Controller {
 			$request->user()->name, 
 			$request->post('message')
 		);
+		return null;
+	}
+
+	public function create_thread(Request $request) {
+		$create = new create_thread;
+		$create->create_thread($request->post('table'));
 		return null;
 	}
 }

--- a/app/Http/Controllers/showTablesCTL.php
+++ b/app/Http/Controllers/showTablesCTL.php
@@ -10,6 +10,7 @@ class showTablesCTL extends Controller {
 		$tableNameArray = $get->showTables();
 		
 		$response['tables'] = $tableNameArray;
+		$response['url'] = url('/');
 		return view('hub', $response);
 	}
 }

--- a/app/Models/create_thread.php
+++ b/app/Models/create_thread.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class create_thread extends Model {
+    public function create_thread($tableName) {
+        Schema::connection('mysql_keiziban')->create($tableName, function (Blueprint $table) {
+            $table->integer('no', 11)->primary();
+            $table->text('name');
+            $table->text('message');
+            $table->text('time');
+        });
+        return null;
+    }
+}

--- a/public/js/Create_thread.js
+++ b/public/js/Create_thread.js
@@ -1,0 +1,28 @@
+/******/ (() => { // webpackBootstrap
+var __webpack_exports__ = {};
+/*!***************************************!*\
+  !*** ./resources/js/Create_thread.js ***!
+  \***************************************/
+$('#create_threadBtn').click(function () {
+  var formElm = document.getElementById("createThread");
+  var threadName = formElm.threadName.value;
+  formElm.threadName.value = "";
+  $.ajaxSetup({
+    headers: {
+      'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+    }
+  });
+  $.ajax({
+    type: "POST",
+    url: url + "/jQuery.ajax/create_thread",
+    data: {
+      "table": threadName
+    }
+  }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+    console.log(XMLHttpRequest.status);
+    console.log(textStatus);
+    console.log(errorThrown.message);
+  });
+});
+/******/ })()
+;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -2,5 +2,6 @@
     "/js/app.js": "/js/app.js",
     "/js/Get_allRow.js": "/js/Get_allRow.js",
     "/js/Send_Row.js": "/js/Send_Row.js",
+    "/js/Create_thread.js": "/js/Create_thread.js",
     "/css/app.css": "/css/app.css"
 }

--- a/resources/js/Create_thread.js
+++ b/resources/js/Create_thread.js
@@ -1,0 +1,24 @@
+$('#create_threadBtn').click(function () {
+	const formElm = document.getElementById("createThread");
+	const threadName = formElm.threadName.value;
+	formElm.threadName.value = "";
+
+	$.ajaxSetup({
+		headers: {
+			'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+		}
+	});
+
+	$.ajax({
+		type: "POST",
+		url: url + "/jQuery.ajax/create_thread",
+		data: {
+			"table": threadName
+		},
+	}).done(function () {
+	}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+		console.log(XMLHttpRequest.status);
+		console.log(textStatus);
+		console.log(errorThrown.message);
+	});
+})

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -619,5 +619,7 @@
     "Email register": "学生番号（e1~）確認メールが送信されます", 
     "Forum Hub": "掲示板ハブ",
     "Go hub": "掲示板ハブへ戻る", 
-    "Write forum": "書き込み"
+    "Write forum": "書き込み",
+    "Create new thread": "新規スレッドの作成",
+    "Thread name": "スレッド名"
 }

--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -10,6 +10,21 @@
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
 
 			<!-- my area begin -->
+            <div>
+                <script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
+                <script>
+                    const url = "{{$url}}";
+                </script>
+            </div>
+            <div>
+                <form id="createThread">
+                    <p>{{__('Thread name')}}<input type="text" name="threadName"></P>
+                </form>
+                <button id="create_threadBtn">{{__('Create new thread')}}</button>
+                <script src="{{ mix('js/Create_thread.js') }}"></script>
+            </div>
+
+                <br><br>
 				<div>
 					@foreach($tables as $tableName)
 						<li><a href="keiziban?table%5B%5D={{$tableName}}">{{$tableName}}</a></li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ Route::get('/', function() {
 
 Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
 Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
+Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
 
 Route::middleware([
     'auth:sanctum',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -15,6 +15,7 @@ const mix = require('laravel-mix');
 mix.js('resources/js/app.js', 'public/js')
     .js('resources/js/Get_allRow.js', 'public/js')
     .js('resources/js/Send_Row.js', 'public/js')
+    .js('resources/js/Create_thread', 'public/js')
     .postCss('resources/css/app.css', 'public/css', [
         require('postcss-import'),
         require('tailwindcss'),


### PR DESCRIPTION
## 関連

- #29 

## なぜこの変更をするのか

- 無し

## やったこと

- スレッド名・作成ボタンを掲示板ハブに追加
- ボタンクリック時の処理を`resources/js/Create_thread.js`ファイルに記述（jQuery.ajax）
- `app/Http/Controllers/jQuery_ajax.php`にスレ立て用のコントローラを追記
- スレッド作成用のモデルを作成（テーブルの追加）

## やらないこと

- スレッドの管理がしやすいように、各スレッドの情報を記録するテーブルを用意
- スレッド名・スレ立て日時の記録

## できるようになること（ユーザ目線）

- スレッド（掲示板）の作成ができる様になる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- さまざまな名前でスレッドが作成できることを確認
- 作成したスレッドに書き込みができることを確認

## その他

スレッドの作成自体はできますが，コンソールに`/jQuery.ajax/create_thread 500 (Internal Server Error)`が出力されます
