### PR TITLE
スレッドの情報をハブに表示

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -27,6 +27,7 @@ class jQuery_ajax extends Controller {
 
 	public function create_thread(Request $request) {
 		$create = new create_thread;
+		$create->insertTable($request->post('table'));
 		$create->create_thread($request->post('table'));
 		return null;
 	}

--- a/app/Http/Controllers/showTablesCTL.php
+++ b/app/Http/Controllers/showTablesCTL.php
@@ -7,9 +7,9 @@ use App\Models\Get;
 class showTablesCTL extends Controller {
 	public function __invoke() {
 		$get = new Get;
-		$tableNameArray = $get->showTables();
+		$stmt = $get->showTables();
 		
-		$response['tables'] = $tableNameArray;
+		$response['tables'] = $stmt;
 		$response['url'] = url('/');
 		return view('hub', $response);
 	}

--- a/app/Models/Get.php
+++ b/app/Models/Get.php
@@ -5,14 +5,10 @@ use Illuminate\Support\Facades\DB;
 
 class Get extends Model {
 	public function showTables() {
-		$tables = DB::connection('mysql_keiziban')->select("SHOW TABLES");
-		$tableNameArray = array_reduce(
-    		array_map(function ($table) {
-				return array_values((array) $table);
-    		}, $tables),
-			'array_merge', []);
-
-		return $tableNameArray;
+		$stmt = json_decode(json_encode(
+			DB::connection('mysql_keiziban')->select("SELECT * FROM hub"),
+		), true);
+		return $stmt;
 	}
 
 	public function allRow($tableName) {

--- a/app/Models/create_thread.php
+++ b/app/Models/create_thread.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
 class create_thread extends Model {
     public function create_thread($tableName) {
         Schema::connection('mysql_keiziban')->create($tableName, function (Blueprint $table) {
-            $table->integer('no', 11)->primary();
+            $table->id('no');
             $table->text('name');
             $table->text('message');
             $table->text('time');

--- a/app/Models/create_thread.php
+++ b/app/Models/create_thread.php
@@ -4,6 +4,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class create_thread extends Model {
     public function create_thread($tableName) {
@@ -13,6 +14,14 @@ class create_thread extends Model {
             $table->text('message');
             $table->text('time');
         });
+
+        return null;
+    }
+
+    public function insertTable($tableName) {
+        DB::connection('mysql_keiziban')->insert(
+        "INSERT INTO hub(id, table_name, created_at) VALUES(NULL, :table_name, NOW())", 
+        [$tableName]);
         return null;
     }
 }

--- a/database/migrations/2022_05_05_112244_create_hub_table.php
+++ b/database/migrations/2022_05_05_112244_create_hub_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateHubTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mysql_keiziban')->create('hub', function (Blueprint $table) {
+            $table->id();
+            $table->string('table_name');
+            $table->string('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('hub');
+    }
+}

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -621,5 +621,6 @@
     "Go hub": "掲示板ハブへ戻る", 
     "Write forum": "書き込み",
     "Create new thread": "新規スレッドの作成",
-    "Thread name": "スレッド名"
+    "Thread name": "スレッド名",
+    "Create time": "作成日時"
 }

--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -24,12 +24,16 @@
                 <script src="{{ mix('js/Create_thread.js') }}"></script>
             </div>
 
-                <br><br>
-				<div>
-					@foreach($tables as $tableName)
-						<li><a href="keiziban?table%5B%5D={{$tableName}}">{{$tableName}}</a></li>
-					@endforeach
-				</div>
+            <br><br>
+            
+            <div>
+                <table>
+                    <tr><th>{{__('Thread name')}}</th><td>{{__('Create time')}}</td></tr>
+                    @foreach($tables as $tableInfo)
+                        <tr><th><a href="keiziban?table%5B%5D={{$tableInfo['table_name']}}">{{$tableInfo['table_name']}}</a></th><td>{{$tableInfo['created_at']}}</td></tr>
+                    @endforeach
+                </table>
+            </div>
 			<!-- my area begin -->
 			
             </div>


### PR DESCRIPTION
## 関連

- #28 
- #29  

## なぜこの変更をするのか

- 無し

## やったこと

- migrationで必須のテーブルを作成（テーブル名: hub）
- スレッド作成時にhubテーブルにテーブル名と作成日時を記録
- ハブで表示されるテーブル名の取得方法を変更
- ハブで各スレッドの情報を表示
- スレッド作成時にコンソールに表示されるエラーを解決

## やらないこと

- この変更によりドキュメントに不要箇所ができたが，ここではドキュメントの修正は行わない

## できるようになること（ユーザ目線）

- 各スレッドの作成日時を知る事ができる様になる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- スレッド作成を行い，エラーが表示されなくなることを確認しました
- スレッド作成を行い，作成日時が表示される事を確認しました
- 作成したスレッドで書き込み・表示ができる事を確認しました

## その他

- 無し
