### PR TITLE
スレッドのコメントに何も入力がされていないと書き込みができない様に

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -17,11 +17,13 @@ class jQuery_ajax extends Controller {
 
 	public function send_Row(Request $request) {
 		$send = new Send;
+		$message = $request->post('message');
+		if (isset($message)) {
 		$send->insertComment(
 			$request->post('table'), 
 			$request->user()->name, 
 			$request->post('message')
-		);
+		);}
 		return null;
 	}
 


### PR DESCRIPTION
## 関連

- #32 

## なぜこの変更をするのか

- なし

## やったこと

- スレッドの書き込みで，コメントを何も入力していない状態で書き込みボタンをクリックしても書き込みできない様にした

## やらないこと

無し

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

- 入力なしのコメントの書き込み（正常な動作）

## 動作確認

- 何も入力していない状態で書き込みボタンをクリックし，書き込みができないことを確認しました
- 入力をしていれば書き込みが可能なことを確認しました

## その他

無し
