### PR TITLE
間違ったメールアドレスで登録してしまった場合の処理

### DIFF
--- a/app/Http/Controllers/AccountDelete.php
+++ b/app/Http/Controllers/AccountDelete.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Actions\Jetstream\DeleteUser;
+
+class AccountDelete extends Controller {
+	public function __invoke(Request $request) {
+		if (!$request->hasValidSignature()) {
+			abort(401);
+		} else {
+			$ctl = new DeleteUser;
+			$ctl->delete($request->user());
+			return redirect('/');
+		}
+		return null;
+	}
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -58,4 +58,9 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $appends = [
         'profile_photo_url',
     ];
+
+    // Add custom mail
+    public function sendEmailVerificationNotification() {
+        $this->notify(new \App\Notifications\VerifyEmailAddURL);
+    }
 }

--- a/app/Notifications/VerifyEmailAddURL.php
+++ b/app/Notifications/VerifyEmailAddURL.php
@@ -40,16 +40,19 @@ class VerifyEmailAddURL extends Notification
     public function toMail($notifiable)
     {
         $verificationUrl = $this->verificationUrl($notifiable);
+        $accountDeleteUrl = $this->accountDeleteUrl($notifiable);
 
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $verificationUrl);
+            return call_user_func(static::$toMailCallback, $notifiable, $verificationUrl, $accountDeleteUrl);
         }
 
         return (new MailMessage)
             ->subject(Lang::get('メールアドレスを認証してください'))
             ->line(Lang::get('以下のボタンをクリックしてメールアドレスを認証してください'))
             ->action(Lang::get('認証する'), $verificationUrl)
-            ->line(Lang::get('（もしこのメールに覚えがない場合は放置して問題ございません）'));
+            ->line(Lang::get('もしこのメールに覚えがない場合はあなたのEmailアドレスがHxSコンピュータ部掲示板サービスのアカウント登録に使用されています．以下のURLにアクセスすると該当アカウントを削除する事ができます'))
+            ->line(Lang::get('放置しても構いません．'))
+            ->line(Lang::get($accountDeleteUrl));
     }
 
     /**
@@ -66,6 +69,21 @@ class VerifyEmailAddURL extends Notification
             [
                 'id' => $notifiable->getKey(),
                 'hash' => sha1($notifiable->getEmailForVerification()),
+            ]
+        );
+    }
+
+    protected function accountDeleteUrl($notifiable) {
+        return URL::temporarySignedRoute(
+            'account/delete',
+            Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
+            [
+                'id' => $notifiable->getKey(),
+                'hash' => sha1(
+                    $notifiable->getKey() . 
+                    $notifiable->getEmailForVerification() . 
+                    $notifiable->getKey()
+                ),
             ]
         );
     }

--- a/app/Notifications/VerifyEmailAddURL.php
+++ b/app/Notifications/VerifyEmailAddURL.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\URL;
+
+class VerifyEmailAddURL extends Notification
+{
+    /**
+     * The callback that should be used to build the mail message.
+     *
+     * @var \Closure|null
+     */
+    public static $toMailCallback;
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $verificationUrl = $this->verificationUrl($notifiable);
+
+        if (static::$toMailCallback) {
+            return call_user_func(static::$toMailCallback, $notifiable, $verificationUrl);
+        }
+
+        return (new MailMessage)
+            ->subject(Lang::get('メールアドレスを認証してください'))
+            ->line(Lang::get('以下のボタンをクリックしてメールアドレスを認証してください'))
+            ->action(Lang::get('認証する'), $verificationUrl)
+            ->line(Lang::get('（もしこのメールに覚えがない場合は放置して問題ございません）'));
+    }
+
+    /**
+     * Get the verification URL for the given notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @return string
+     */
+    protected function verificationUrl($notifiable)
+    {
+        return URL::temporarySignedRoute(
+            'verification.verify',
+            Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
+            [
+                'id' => $notifiable->getKey(),
+                'hash' => sha1($notifiable->getEmailForVerification()),
+            ]
+        );
+    }
+
+    /**
+     * Set a callback that should be used when building the notification mail message.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function toMailUsing($callback)
+    {
+        static::$toMailCallback = $callback;
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,14 +12,11 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::get('/', function() {
-	return view('welcome');
-});
-
+Route::get('/', function() { return view('welcome');});
 Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
 Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
 Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
-Route::get('/account/delete/{id}/{hash}', 'App\Http\Controllers\AccountDelete')->name('account/delete');
+Route::get('/account/delete/{id}/{hash}', 'App\Http\Controllers\AccountDelete')->middleware('auth')->name('account/delete');
 
 Route::middleware([
     'auth:sanctum',

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ Route::get('/', function() {
 Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
 Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
 Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
+Route::get('/account/delete/{id}/{hash}', 'App\Http\Controllers\AccountDelete')->name('account/delete');
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
## 関連

- #11 

## なぜこの変更をするのか

- 無し

## やったこと

- 送信されるメールの編集（削除用URLを送信）
- 削除用URLでアクセスされた場合該当アカウントを削除
- 削除用URLで2度以上アクセスされた場合のエラーをmiddlwareで防ぐ
- 削除用URLでアクセスされた場合welcome画面へリダイレクトする

## やらないこと

- メール検証後，すぐさま削除用URLを無効にすること（時間経過で無効になるようです）

## できるようになること（ユーザ目線）

- 間違って自分以外のメールアドレスで登録された場合，該当アカウントを削除できる様になる（時間制限あり）

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 削除用URLでアクセスした際にアカウントが削除されることを確認しました
- 削除用URLで複数回アクセスした際にエラーが表示さずにログイン画面へ遷移する事を確認しました

## その他

- 時間経過で無効化されるのかは検証しておりません
