### PR TITLE
空白の表示・特殊文字の置換

### DIFF
--- a/app/Models/Send.php
+++ b/app/Models/Send.php
@@ -5,7 +5,20 @@ use Illuminate\Support\Facades\DB;
 
 class Send extends Model {
 	public function insertComment($table, $name, $message) {
-		$message = str_replace("\n", "<br>", $message);
+		$special_character_set = array (
+			"&" => "&amp;",
+			"<" => "&lt;",
+			">" => "&gt;",
+			" " => "&ensp;",
+			"　" => "&emsp;",
+			"\n" => "<br>",
+			"\t" => "&ensp;&ensp;"
+		);
+		
+		foreach ($special_character_set as $key => $value) {
+			$message = str_replace($key, $value, $message);
+		}
+
 		DB::connection('mysql_keiziban')->insert(
 			"INSERT INTO $table(no, name, message, time) VALUES(NULL, :name, :message, NOW())", 
 			[$name, $message]);


### PR DESCRIPTION
## 関連

- #27 

## なぜこの変更をするのか

- 行頭での空白が可能になることで表現の幅が増えるから

## やったこと

- 半角・全角スペースを表示可能に
- <>で囲まれた部分がタグとして認識されないように
- タブを半角スペース2つに
- &を置換することで特殊文字の入力によって変換されないように

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 行頭に空白の入力が可能になる

## できなくなること（ユーザ目線）

- 特殊文字の入力によって変換が起こらなくなる（正常な動作）

## 動作確認

- 置換対象の文字を入力して変換される事を確認した
- いくつかの特殊文字を入力して変換が起こらない事を確認した

## その他

- 入力制限（行数制限）が必要かと思います
- 空白・改行のみの入力はできない様にした方がいいかと思います
