### PR TITLE
いいね機能の追加（未完）

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -41,10 +41,11 @@ class jQuery_ajax extends Controller {
 		$user_id = $request->user()->id;
 
 		$like = new Like;
-		$like->thread_id = $thread_id;
-		$like->message_id = $message_id;
-		$like->user_id = $user_id;
-		$like->save();
+		$like->like(
+			$thread_id,
+			$message_id,
+			$user_id
+		);
 
 		return null;
 	}

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Get;
 use App\Models\Send;
 use App\Models\create_thread;
+use App\Models\Like;
 
 class jQuery_ajax extends Controller {
 	public function get_allRow(Request $request) {
@@ -31,6 +32,20 @@ class jQuery_ajax extends Controller {
 		$create = new create_thread;
 		$create->insertTable($request->post('table'));
 		$create->create_thread($request->post('table'));
+		return null;
+	}
+
+	public function like(Request $request) {
+		$thread_id = $request->thread_id;
+		$message_id = $request->message_id;
+		$user_id = $request->user()->id;
+
+		$like = new Like;
+		$like->thread_id = $thread_id;
+		$like->message_id = $message_id;
+		$like->user_id = $user_id;
+		$like->save();
+
 		return null;
 	}
 }

--- a/app/Http/Controllers/keizibanCTL.php
+++ b/app/Http/Controllers/keizibanCTL.php
@@ -11,6 +11,7 @@ class keizibanCTL extends Controller {
 		$stmt = $get->allRow($request->table);
 
 		$response['tableName'] = $request->table;
+		$response['thread_id'] = $request->thread_id;
 		$response['username'] = $request->user()->name;
 		$response['url'] = url('/');
 		$response['allRow'] = $stmt;

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -4,8 +4,42 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class Like extends Model {
-    protected $connection = 'mysql_keiziban';
-    protected $fillable = ['thread_id', 'message_id', 'user_id'];
+    public function like($thread_id, $message_id, $user_id) {
+        $query =<<<EOM
+        INSERT INTO
+            likes
+        SELECT
+            NULL,
+            $thread_id,
+            $message_id,
+            $user_id,
+            NOW(),
+            NULL
+        FROM
+            DUAL
+        WHERE
+            NOT EXISTS(
+                SELECT
+                    *
+                FROM
+                    likes
+                WHERE
+                    thread_id = :thread_id AND
+                    message_id = :message_id AND
+                    user_id = :user_id
+            );
+        EOM;
+        
+        DB::connection('mysql_keiziban')->insert(
+            $query, [
+                'thread_id' => $thread_id, 
+                'message_id' => $message_id, 
+                'user_id' => $user_id,
+            ]
+        );
+        return null;
+    }
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Like extends Model {
+    protected $connection = 'mysql_keiziban';
+    protected $fillable = ['thread_id', 'message_id', 'user_id'];
+}

--- a/database/migrations/2022_05_09_134146_create_likes_table.php
+++ b/database/migrations/2022_05_09_134146_create_likes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLikesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mysql_keiziban')->create('likes', function (Blueprint $table) {
+            $table->id();
+            $table->integer('thread_id')->unsigned();
+            $table->integer('message_id')->unsigned();
+            $table->integer('user_id')->unsigned();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('likes');
+    }
+}

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -28,7 +28,7 @@ function reload() {
     displayArea.innerHTML = "<br>";
 
     for (var item in data) {
-      displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + data[item]['message'] + "<hr><br>");
+      displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + data[item]['message'] + "<br>" + "<button type='button' class='btn btn-secondary' onClick='like(" + data[item]['no'] + ")'>like</button>" + "<hr>");
     }
   }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
     console.log(XMLHttpRequest.status);

--- a/resources/js/Get_allRow.js
+++ b/resources/js/Get_allRow.js
@@ -20,8 +20,13 @@ function reload(){
     }).done(function (data) {
         displayArea.innerHTML = "<br>";
         for (var item in data) {
-            displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" +
-                data[item]['message'] + "<hr><br>");
+            displayArea.insertAdjacentHTML('afterbegin',
+            data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + 
+            "<br>" +
+            data[item]['message'] +
+            "<br>" +
+            "<button type='button' class='btn btn-secondary' onClick='like(" + data[item]['no'] + ")'>like</button>" +
+            "<hr>");
         }
     }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
         console.log(XMLHttpRequest.status);
@@ -29,3 +34,5 @@ function reload(){
         console.log(errorThrown.message);
     });
 }
+
+

--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -40,7 +40,7 @@
 							</thead>
 							<tbody>
 								@foreach($tables as $tableInfo)
-									<tr><th><a href="hub/keiziban={{$tableInfo['table_name']}}">{{$tableInfo['table_name']}}</a></th><td>{{$tableInfo['created_at']}}</td></tr>
+									<tr><th><a href="hub/keiziban={{ $tableInfo['table_name'] }}&thread_id={{ $tableInfo['id'] }}">{{$tableInfo['table_name']}}</a></th><td>{{$tableInfo['created_at']}}</td></tr>
 								@endforeach
 							</tbody>
 						</table>

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -27,6 +27,7 @@
 					<script>
 						const url = "{{$url}}";
 						const table = "{{$tableName}}";
+						const thread_id = "{{$thread_id}}";
 					</script>
 
 					<script>
@@ -41,7 +42,7 @@
 								type:"POST",
 								url: url + "/jQuery.ajax/like",
 								data: {
-									"thread_id": table,
+									"thread_id": thread_id,
 									"message_id": message_id
 								}
 							}).done(function () {

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -19,6 +19,39 @@
 					rel="stylesheet" 
 					integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" 
 					crossorigin="anonymous">
+
+					<!-- jQuery -->
+					<script src="https://code.jquery.com/jquery-3.0.0.min.js"></script> 
+					
+					<!-- グローバル変数 -->
+					<script>
+						const url = "{{$url}}";
+						const table = "{{$tableName}}";
+					</script>
+
+					<script>
+						function like(message_id) {
+							$.ajaxSetup({
+								headers: {
+									'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+								}
+							});
+
+							$.ajax({
+								type:"POST",
+								url: url + "/jQuery.ajax/like",
+								data: {
+									"thread_id": table,
+									"message_id": message_id
+								}
+							}).done(function () {
+							}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+								console.log(XMLHttpRequest.status);
+								console.log(textStatus);
+								console.log(errorThrown.message);
+							});
+						}
+					</script>
 				</head>
 
 				<body>
@@ -55,15 +88,6 @@
 						integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" 
 						crossorigin="anonymous"
 						></script> 
-						
-						<!-- jQuery -->
-						<script src="https://code.jquery.com/jquery-3.0.0.min.js"></script> 
-						
-						<!-- グローバル変数 -->
-						<script>
-							const url = "{{$url}}";
-							const table = "{{$tableName}}";
-						</script> 
 						
 						<!-- others -->
 						<script src="{{ mix('js/app_jquery.js') }}"></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,11 +13,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// データ処理
-Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
-Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
-Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
-
 // 画面遷移
 Route::get('/', function() { return view('welcome');});
 Route::get('/account/delete/{id}/{hash}', 'App\Http\Controllers\AccountDelete')->middleware('auth')->name('account/delete');
@@ -31,4 +26,10 @@ Route::middleware([
     Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
     Route::get('hub/keiziban={table}', 'App\Http\Controllers\keizibanCTL')->name('keiziban');
     Route::get('/mypage', 'App\Http\Controllers\MyPage')->name('mypage');
+
+    // データ処理
+    Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
+    Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
+    Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
+    Route::post('jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Route::middleware([
 ])->group(function () {
     Route::get('/dashboard', function () { return view('dashboard'); })->name('dashboard');
     Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
-    Route::get('hub/keiziban={table}', 'App\Http\Controllers\keizibanCTL')->name('keiziban');
+    Route::get('hub/keiziban={table}&thread_id={thread_id}', 'App\Http\Controllers\keizibanCTL')->name('keiziban');
     Route::get('/mypage', 'App\Http\Controllers\MyPage')->name('mypage');
 
     // データ処理


### PR DESCRIPTION
## 関連

- #23

## なぜこの変更をするのか

- 無し

## やったこと

- 掲示板にいいね用ボタンを設置
- いいねを保存するテーブルを追加（マイグレーション）
- いいねを押せる数を1人・1書き込みにつき1つに制限する
- 各コメントのいいねボタンが押された回数をカウントしてテーブルに保存する

## やらないこと

- コメントのいいねボタンが押された回数をそのコメントに表示する

## できるようになること（ユーザ目線）

- 各コメントにいいねを押すことができるようになる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- いいねボタンを複数回クリックして，レコードが重複しないことを確認
- 複数の書き込みで同様の動作をする事を確認

## その他

- いいねの数を表示させるのにはテーブルの大きな変更が必要なため，いったんマージします
