### PR TITLE
大学アカウントのパスワードで登録・入力しないようにメッセージを表示

### DIFF
--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -616,12 +616,14 @@
     "Zambia": "Zambia",
     "Zimbabwe": "Zimbabwe",
 
-    "Email register": "学生番号（e1~）確認メールが送信されます", 
+    "Email register": "学生番号：(e1~... @以下不要) 確認メールが送信されます", 
     "Forum Hub": "掲示板ハブ",
     "Go hub": "掲示板ハブへ戻る", 
     "Write forum": "書き込み",
     "Create new thread": "新規スレッドの作成",
     "Thread name": "スレッド名",
     "Create time": "作成日時",
-    "My page": "マイページ"
+    "My page": "マイページ",
+    "Password register notice": "：大学アカウントのパスワードでは登録しないでください",
+    "Password login notice": "：大学アカウントのパスワードを入力しないでください"
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -21,7 +21,7 @@
             </div>
 
             <div class="mt-4">
-                <x-jet-label for="password" value="{{ __('Password') }}" />
+                <x-jet-label for="password" value="{{ __('Password') }}{{ __('Password login notice') }}" />
                 <x-jet-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="current-password" />
             </div>
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -4,6 +4,12 @@
             <x-jet-authentication-card-logo />
         </x-slot>
 
+        <!-- Bootstrap CSS -->
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" 
+        rel="stylesheet" 
+        integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" 
+        crossorigin="anonymous">
+
         <x-jet-validation-errors class="mb-4" />
 
         <form method="POST" action="{{ route('register') }}">
@@ -20,7 +26,7 @@
             </div>
 
             <div class="mt-4">
-                <x-jet-label for="password" value="{{ __('Password') }}" />
+                <x-jet-label for="password" value="{{ __('Password') }}{{ __('Password register notice') }}" />
                 <x-jet-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
             </div>
 
@@ -45,6 +51,10 @@
                     </x-jet-label>
                 </div>
             @endif
+
+            <div class="mt-4">
+                <p class="text-danger">{{__('Registration notice')}}</p>
+            </div>
 
             <div class="flex items-center justify-end mt-4">
                 <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('login') }}">

--- a/resources/views/profile/update-password-form.blade.php
+++ b/resources/views/profile/update-password-form.blade.php
@@ -15,7 +15,7 @@
         </div>
 
         <div class="col-span-6 sm:col-span-4">
-            <x-jet-label for="password" value="{{ __('New Password') }}" />
+            <x-jet-label for="password" value="{{ __('New Password') }}{{ __('Password register notice') }}" />
             <x-jet-input id="password" type="password" class="mt-1 block w-full" wire:model.defer="state.password" autocomplete="new-password" />
             <x-jet-input-error for="password" class="mt-2" />
         </div>


### PR DESCRIPTION
## 関連

- #37 

## なぜこの変更をするのか

無し

## やったこと

- 新規登録時のパスワード入力欄で，アカウントのパスワードで登録しないように注意喚起のメッセージを追加
- ログイン時のパスワード入力欄で，アカウントのパスワードを入力しないように注意喚起のメッセージを追加
- パスワード変更のformでアカウントのパスワードを入力しないように注意喚起のメッセージを追加

## やらないこと

無し

## できるようになること（ユーザ目線）

- パスワード入力時に警告メッセージを見れるようになる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 新規登録時のパスワード入力欄で注意喚起メッセージが表示されることを確認
- ログイン時のパスワード入力欄で注意喚起メッセージが表示されることを確認
- パスワード変更用のformで注意喚起メッセージが表示が表示されることを確認

## その他

無し
