### PR TITLE
書き込み制限の追加

### DIFF
--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -48,27 +48,38 @@ function reload() {
   !*** ./resources/js/Send_Row.js ***!
   \**********************************/
 $('#sendMessageBtn').click(function () {
+  var sendAlertArea = document.getElementById("sendAlertArea");
   var formElm = document.getElementById("sendMessage");
   var message = formElm.message.value;
-  formElm.message.value = '';
-  $.ajaxSetup({
-    headers: {
-      'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-    }
-  });
-  $.ajax({
-    type: "POST",
-    url: url + "/jQuery.ajax/sendRow",
-    data: {
-      "table": thread_id,
-      "message": message
-    }
-  }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-    console.log(XMLHttpRequest.status);
-    console.log(textStatus);
-    console.log(errorThrown.message);
-  });
+
+  if (message.trim() == 0) {
+    sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
+  } else {
+    sendAlertArea.innerHTML = "";
+    $.ajaxSetup({
+      headers: {
+        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+      }
+    });
+    $.ajax({
+      type: "POST",
+      url: url + "/jQuery.ajax/sendRow",
+      data: {
+        "table": thread_id,
+        "message": message
+      }
+    }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+      console.log(XMLHttpRequest.status);
+      console.log(textStatus);
+      console.log(errorThrown.message);
+    });
+    formElm.message.value = '';
+  }
 });
+
+String.prototype.bytes = function () {
+  return encodeURIComponent(this).replace(/%../g, "x").length;
+};
 })();
 
 // This entry need to be wrapped in an IIFE because it need to be isolated against other entry modules.

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -48,14 +48,18 @@ function reload() {
   !*** ./resources/js/Send_Row.js ***!
   \**********************************/
 $('#sendMessageBtn').click(function () {
+  var rows_limit = 20;
+  var bytes_limit = 300;
   var sendAlertArea = document.getElementById("sendAlertArea");
   var formElm = document.getElementById("sendMessage");
   var message = formElm.message.value;
 
   if (message.trim() == 0) {
     sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
-  } else if (message.rows() > 20) {
-    sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は10行以内にして下さい</div>";
+  } else if (message.rows() > rows_limit) {
+    sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + rows_limit + "行以内にして下さい</div>";
+  } else if (message.bytes() > bytes_limit) {
+    sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + bytes_limit / 3 + "文字(英数字は " + bytes_limit + "文字)以内にして下さい</div>";
   } else {
     sendAlertArea.innerHTML = "";
     $.ajaxSetup({

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -54,6 +54,8 @@ $('#sendMessageBtn').click(function () {
 
   if (message.trim() == 0) {
     sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
+  } else if (message.rows() > 20) {
+    sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は10行以内にして下さい</div>";
   } else {
     sendAlertArea.innerHTML = "";
     $.ajaxSetup({
@@ -79,6 +81,10 @@ $('#sendMessageBtn').click(function () {
 
 String.prototype.bytes = function () {
   return encodeURIComponent(this).replace(/%../g, "x").length;
+};
+
+String.prototype.rows = function () {
+  if (this.match(/\n/g)) return this.match(/\n/g).length + 1;else return 1;
 };
 })();
 

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -31,7 +31,7 @@ function reload() {
       displayArea.innerHTML = "<br>";
 
       for (var item in data) {
-        displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + data[item]['message'] + "<br>" + "<button type='button' class='btn btn-secondary' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
+        displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-secondary' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
       }
     }
   }).fail(function (XMLHttpRequest, textStatus, errorThrown) {

--- a/resources/js/Get_allRow.js
+++ b/resources/js/Get_allRow.js
@@ -29,7 +29,9 @@ function reload(){
                 displayArea.insertAdjacentHTML('afterbegin',
                 data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + 
                 "<br>" +
+                "<p style='overflow-wrap: break-word;'>" +
                 data[item]['message'] +
+                "</p>" +
                 "<br>" +
                 "<button type='button' class='btn btn-secondary' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] +
                 "<hr>");

--- a/resources/js/Send_Row.js
+++ b/resources/js/Send_Row.js
@@ -5,8 +5,11 @@ $('#sendMessageBtn').click(function () {
 
 	if (message.trim() == 0) {
 		sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
+	} else if (message.rows() > 20) {
+		sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は10行以内にして下さい</div>";
 	} else {
 		sendAlertArea.innerHTML = "";
+
 		$.ajaxSetup({
 			headers: {
 				'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
@@ -32,4 +35,8 @@ $('#sendMessageBtn').click(function () {
 
 String.prototype.bytes = function () {
 	return(encodeURIComponent(this).replace(/%../g,"x").length);
+}
+
+String.prototype.rows = function () {
+	if (this.match(/\n/g)) return(this.match(/\n/g).length) + 1; else return(1);
 }

--- a/resources/js/Send_Row.js
+++ b/resources/js/Send_Row.js
@@ -1,12 +1,16 @@
 $('#sendMessageBtn').click(function () {
+	var rows_limit = 20;
+	var bytes_limit = 300;
 	var sendAlertArea = document.getElementById("sendAlertArea");
 	var formElm = document.getElementById("sendMessage");
 	var message = formElm.message.value;
 
 	if (message.trim() == 0) {
 		sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
-	} else if (message.rows() > 20) {
-		sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は10行以内にして下さい</div>";
+	} else if (message.rows() > rows_limit) {
+		sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + rows_limit + "行以内にして下さい</div>";
+	} else if (message.bytes() > bytes_limit) {
+		sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + bytes_limit / 3 + "文字(英数字は " + bytes_limit + "文字)以内にして下さい</div>";
 	} else {
 		sendAlertArea.innerHTML = "";
 

--- a/resources/js/Send_Row.js
+++ b/resources/js/Send_Row.js
@@ -1,25 +1,35 @@
 $('#sendMessageBtn').click(function () {
-	const formElm = document.getElementById("sendMessage");
-	const message = formElm.message.value;
-	formElm.message.value = '';
+	var sendAlertArea = document.getElementById("sendAlertArea");
+	var formElm = document.getElementById("sendMessage");
+	var message = formElm.message.value;
 
-	$.ajaxSetup({
-		headers: {
-			'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-		}
-	});
-
-	$.ajax({
-		type: "POST",
-		url: url + "/jQuery.ajax/sendRow",
-		data: {
-			"table": thread_id,
-			"message": message
-		},
-	}).done(function () {
-	}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-		console.log(XMLHttpRequest.status);
-		console.log(textStatus);
-		console.log(errorThrown.message);
-	});
+	if (message.trim() == 0) {
+		sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
+	} else {
+		sendAlertArea.innerHTML = "";
+		$.ajaxSetup({
+			headers: {
+				'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+			}
+		});
+	
+		$.ajax({
+			type: "POST",
+			url: url + "/jQuery.ajax/sendRow",
+			data: {
+				"table": thread_id,
+				"message": message
+			},
+		}).done(function () {
+		}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+			console.log(XMLHttpRequest.status);
+			console.log(textStatus);
+			console.log(errorThrown.message);
+		});
+		formElm.message.value = '';
+	}
 });
+
+String.prototype.bytes = function () {
+	return(encodeURIComponent(this).replace(/%../g,"x").length);
+}

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -79,7 +79,7 @@
 								<button id="sendMessageBtn" class="btn btn-primary">{{__('Write forum')}}</button>
 							</div>
 
-							<div id="displayArea" data-bs-spy="scroll" class="col-8 overflow-auto" style="position:relative; height:70vh; overflow:scroll"></div>
+							<div id="displayArea" class="col-8" style="height:70vh; width: 100% overflow-y:scroll; overflow-x:hidden;"></div>
 
 						</div>
 					</div>

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -71,7 +71,9 @@
 									<div class="mb-2">
 										<label class="form-label">コメント</label>
 										<textarea class="form-control" name="message" rows="7"></textarea>
+										<br>
 										<div class="form-text">入力欄の右下にマウスカーソルを移動させると，高さを変えることができます</div>
+										<div id="sendAlertArea"></div>
 									</div>
 								</form>
 								<button id="sendMessageBtn" class="btn btn-primary">{{__('Write forum')}}</button>


### PR DESCRIPTION
## 関連

- #44 
- #45 

## なぜこの変更をするのか

無し

## やったこと

- 入力が無い状態での書き込みをできない様に
- 改行・空白のみの入力ができない様に
- 書き込みに行数制限
- 書き込みに文字数制限
- 投稿の表示で，横スクロールを廃止・自動折り返しを有効に

## やらないこと

- 長文の場合に表示されるものを省略し，利用者が見ようと思ったときだけ見れる様にすること

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 制限なしの書き込みが出来なくなる

## 動作確認

- 各制限前後の行数・文字数で書き込みを行い，制限がされる事を確認した

## その他

無し