### PR TITLE
データ処理以外からのアクセスを404にする

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'AccessGET' => \App\Http\Middleware\AccessGET::class,
     ];
 }

--- a/app/Http/Middleware/AccessGET.php
+++ b/app/Http/Middleware/AccessGET.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class AccessGET
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        abort(404);
+        exit;
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,22 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function() { return view('welcome');});
 Route::get('/account/delete/{id}/{hash}', 'App\Http\Controllers\AccountDelete')->middleware('auth')->name('account/delete');
 
+// URLからのアクセス対策
+Route::middleware([
+    'AccessGET'
+])->group(function () {
+    Route::get('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
+    Route::get('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
+    Route::get('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
+    Route::get('jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
+});
+
+// データ処理
+Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
+Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
+Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
+Route::post('jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
+
 Route::middleware([
     'auth:sanctum',
     config('jetstream.auth_session'),
@@ -26,10 +42,4 @@ Route::middleware([
     Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
     Route::get('hub/thread_name={thread_name}/id={thread_id}', 'App\Http\Controllers\keizibanCTL')->name('keiziban');
     Route::get('/mypage', 'App\Http\Controllers\MyPage')->name('mypage');
-
-    // データ処理
-    Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
-    Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
-    Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
-    Route::post('jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
 });


### PR DESCRIPTION
## 関連

- #46 

## なぜこの変更をするのか

無し

## やったこと

- Routeにデータ処理用URL（POSTメソッド）と同じURLのGETメソッドバージョンを登録
- URL入力でのアクセス（GETメソッド）からのアクセスには404を返すミドルウェアを追加

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 全てのデータ処理用URLにアクセスして，404が表示される事を確認しました

## その他

無し
