### PR TITLE
スレッドに書き込んだユーザを想定するあらゆる状況で特定する

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -28,6 +28,7 @@ class jQuery_ajax extends Controller {
 		$send->insertComment(
 			$request->post('table'), 
 			$request->user()->name, 
+			$request->user()->email,
 			$request->post('message')
 		);}
 		return null;
@@ -39,7 +40,7 @@ class jQuery_ajax extends Controller {
 		$create->insertTable(
 			$request->post('table'),
 			$uuid,
-			$request->user()->id
+			$request->user()->email
 		);
 		$create->create_thread($uuid);
 		return null;

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -36,7 +36,11 @@ class jQuery_ajax extends Controller {
 	public function create_thread(Request $request) {
 		$create = new create_thread;
 		$uuid = str_replace("-", "", Str::uuid());
-		$create->insertTable($request->post('table'), $uuid);
+		$create->insertTable(
+			$request->post('table'),
+			$uuid,
+			$request->user()->id
+		);
 		$create->create_thread($uuid);
 		return null;
 	}

--- a/app/Models/Send.php
+++ b/app/Models/Send.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 class Send extends Model {
-	public function insertComment($table, $name, $message) {
+	public function insertComment($table, $name, $user_email, $message) {
 		$special_character_set = array (
 			"&" => "&amp;",
 			"<" => "&lt;",
@@ -20,8 +20,8 @@ class Send extends Model {
 		}
 
 		DB::connection('mysql_keiziban')->insert(
-			"INSERT INTO $table(no, name, message, time) VALUES(NULL, :name, :message, NOW())", 
-			[$name, $message]);
+			"INSERT INTO $table(no, name, user_email, message, time) VALUES(NULL, :name, :user_email, :message, NOW())", 
+			[$name, $user_email, $message]);
 		return null;
 	}
 }

--- a/app/Models/create_thread.php
+++ b/app/Models/create_thread.php
@@ -10,7 +10,8 @@ class create_thread extends Model {
     public function create_thread($thread_id) {
         Schema::connection('mysql_keiziban')->create($thread_id, function (Blueprint $table) {
             $table->id('no');
-            $table->text('user_id');
+            $table->text('name');
+            $table->text('user_email');
             $table->text('message');
             $table->text('time');
         });
@@ -18,10 +19,10 @@ class create_thread extends Model {
         return null;
     }
 
-    public function insertTable($tableName, $thread_id, $user_id) {
+    public function insertTable($tableName, $thread_id, $user_email) {
         DB::connection('mysql_keiziban')->insert(
-        "INSERT INTO hub(id, thread_id, thread_name, user_id, created_at) VALUES(NULL, :thread_id, :thread_name, :user_id, NOW())", 
-        [$thread_id, $tableName, $user_id]);
+        "INSERT INTO hub(id, thread_id, thread_name, user_email, created_at) VALUES(NULL, :thread_id, :thread_name, :user_email, NOW())", 
+        [$thread_id, $tableName, $user_email]);
         return null;
     }
 }

--- a/app/Models/create_thread.php
+++ b/app/Models/create_thread.php
@@ -10,7 +10,7 @@ class create_thread extends Model {
     public function create_thread($thread_id) {
         Schema::connection('mysql_keiziban')->create($thread_id, function (Blueprint $table) {
             $table->id('no');
-            $table->text('name');
+            $table->text('user_id');
             $table->text('message');
             $table->text('time');
         });
@@ -18,10 +18,10 @@ class create_thread extends Model {
         return null;
     }
 
-    public function insertTable($tableName, $thread_id) {
+    public function insertTable($tableName, $thread_id, $user_id) {
         DB::connection('mysql_keiziban')->insert(
-        "INSERT INTO hub(id, thread_id, thread_name, created_at) VALUES(NULL, :thread_id, :thread_name, NOW())", 
-        [$thread_id, $tableName]);
+        "INSERT INTO hub(id, thread_id, thread_name, user_id, created_at) VALUES(NULL, :thread_id, :thread_name, :user_id, NOW())", 
+        [$thread_id, $tableName, $user_id]);
         return null;
     }
 }

--- a/database/migrations/2022_05_05_112244_create_hub_table.php
+++ b/database/migrations/2022_05_05_112244_create_hub_table.php
@@ -17,7 +17,7 @@ class CreateHubTable extends Migration
             $table->id();
             $table->string('thread_id');
             $table->string('thread_name');
-            $table->string('user_id');
+            $table->string('user_email');
             $table->string('created_at');
         });
     }

--- a/database/migrations/2022_05_05_112244_create_hub_table.php
+++ b/database/migrations/2022_05_05_112244_create_hub_table.php
@@ -17,6 +17,7 @@ class CreateHubTable extends Migration
             $table->id();
             $table->string('thread_id');
             $table->string('thread_name');
+            $table->string('user_id');
             $table->string('created_at');
         });
     }


### PR DESCRIPTION
## 関連

- #48 

## なぜこの変更をするのか

無し

## やったこと

- スレッドを作成したユーザを保存
- スレッドに書き込んだユーザのEmailを追加で保存

## やらないこと

- ユーザIDをランダムに生成し，変更不可にすること

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

- 同一Emailのアカウントの場合，異なるユーザ扱いでスレッドに書き込みを行えなくなる

## 動作確認

- スレッドを作成した際に，ユーザ（Email）が保存されている事を確認
- スレッドに書き込んだ際にユーザEmailを追加で保存される事を確認

## その他

- ユーザIDをランダム生成する方法が分かりませんでした
- 書き込み表示時に保存されたユーザEmailを利用してユーザテーブルから名前を取得する事で，ユーザ名を変更した際に過去のユーザ名を表示出来る様にするのは出来ませんでした．ユーザテーブルと掲示板テーブルが別データベースに存在するため．