### PR TITLE
ボタンクリック時にいいねがすでに押されていればいいねを取り消す

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -63,4 +63,18 @@ class jQuery_ajax extends Controller {
 
 		return null;
 	}
+
+	public function unlike(Request $request) {
+		$thread_id = $request->thread_id;
+		$message_id = $request->message_id;
+		$user_id = $request->user()->id;
+
+		$like = new Like;
+		$like->unlike(
+			$thread_id,
+			$message_id,
+			$user_id
+		);
+		return null;
+	}
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -10,7 +10,7 @@ class Like extends Model {
     public function like($thread_id, $message_id, $user_id) {
         $thread_id = htmlspecialchars($thread_id, ENT_QUOTES, 'UTF-8');
         
-        $query =<<<EOM
+        $query =<<<EOF
         INSERT INTO
             likes
         SELECT
@@ -33,7 +33,7 @@ class Like extends Model {
                     message_id = :message_id AND
                     user_id = :user_id
             );
-        EOM;
+        EOF;
         
         DB::connection('mysql_keiziban')->insert(
             $query, [
@@ -42,6 +42,23 @@ class Like extends Model {
                 'user_id' => $user_id,
             ]
         );
+        return null;
+    }
+
+    public function unlike($thread_id, $message_id, $user_id) {
+        $thread_id = htmlspecialchars($thread_id, ENT_QUOTES, 'UTF-8');
+        
+        $query =<<<EOF
+        DELETE
+        FROM
+            likes
+        WHERE
+            likes.thread_id = '$thread_id' AND
+            likes.message_id = $message_id AND
+            likes.user_id = $user_id
+        EOF;
+
+        DB::connection('mysql_keiziban')->delete($query);
         return null;
     }
 }

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -32,9 +32,9 @@ function reload() {
 
       for (var item in data) {
         if (data[item]['user_like'] == 1) {
-          displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
+          displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
         } else {
-          displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
+          displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
         }
       }
     }

--- a/resources/js/Get_allRow.js
+++ b/resources/js/Get_allRow.js
@@ -34,7 +34,7 @@ function reload(){
                     data[item]['message'] +
                     "</p>" +
                     "<br>" +
-                    "<button type='button' class='btn btn-dark' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] +
+                    "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
                     "<hr>");
                 } else {
                     displayArea.insertAdjacentHTML('afterbegin',
@@ -44,7 +44,7 @@ function reload(){
                     data[item]['message'] +
                     "</p>" +
                     "<br>" +
-                    "<button type='button' class='btn btn-light' onClick='like(" + data[item]['no'] + ")'>like</button> " + data[item]['count_user'] +
+                    "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
                     "<hr>");
                 }
             }

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -31,26 +31,42 @@
 					</script>
 
 					<script>
-						function like(message_id) {
+						function likes(message_id, user_like) {
 							$.ajaxSetup({
 								headers: {
 									'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
 								}
 							});
 
-							$.ajax({
-								type:"POST",
-								url: url + "/jQuery.ajax/like",
-								data: {
-									"thread_id": thread_id,
-									"message_id": message_id
-								}
-							}).done(function () {
-							}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-								console.log(XMLHttpRequest.status);
-								console.log(textStatus);
-								console.log(errorThrown.message);
-							});
+							if (user_like == 1) {
+								$.ajax({
+									type:"POST",
+									url: url + "/jQuery.ajax/unlike",
+									data: {
+										"thread_id": thread_id,
+										"message_id": message_id
+									}
+								}).done(function () {
+								}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+									console.log(XMLHttpRequest.status);
+									console.log(textStatus);
+									console.log(errorThrown.message);
+								});
+							} else {
+								$.ajax({
+									type:"POST",
+									url: url + "/jQuery.ajax/like",
+									data: {
+										"thread_id": thread_id,
+										"message_id": message_id
+									}
+								}).done(function () {
+								}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+									console.log(XMLHttpRequest.status);
+									console.log(textStatus);
+									console.log(errorThrown.message);
+								});
+							}
 						}
 					</script>
 				</head>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// 画面遷移
 Route::get('/', function() { return view('welcome');});
 Route::get('/account/delete/{id}/{hash}', 'App\Http\Controllers\AccountDelete')->middleware('auth')->name('account/delete');
 
@@ -25,6 +24,7 @@ Route::middleware([
     Route::get('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
     Route::get('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
     Route::get('jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
+    Route::get('jQuery.ajax/unlike', "App\Http\Controllers\jQuery_ajax@unlike");
 });
 
 // データ処理
@@ -32,6 +32,7 @@ Route::post('jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow")
 Route::post('jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
 Route::post('jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
 Route::post('jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
+Route::post('jQuery.ajax/unlike', "App\Http\Controllers\jQuery_ajax@unlike");
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
## 関連

- #55 

## なぜこの変更をするのか

無し

## やったこと

- いいね取り消し用のコントローラ・モデルの作成
- いいねボタンが押された際にすでに押されているかで処理を分割

## やらないこと

無し

## できるようになること（ユーザ目線）

コメントに対するいいねの取り消しが可能になる

## できなくなること（ユーザ目線）

無し

## 動作確認

- いいね状態のボタンをクリックした際にいいねが取り消されることを確認
- 同状況でlikesテーブルの該当レコードを削除されることを確認

## その他

無し