### PR TITLE
スレッド名にバックスラッシュが含まれている場合でもスレッドページに移動

### DIFF
--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -40,7 +40,11 @@
 							</thead>
 							<tbody>
 								@foreach($tables as $tableInfo)
-									<tr><th><a href="hub/thread_name={{ $tableName = str_replace('/', '&slash;', $tableInfo['thread_name']); }}/id={{ $tableInfo['thread_id'] }}">{{$tableInfo['thread_name']}}</a></th><td>{{$tableInfo['created_at']}}</td></tr>
+									<?php
+										$tableName = str_replace('/', '&slash;', $tableInfo['thread_name']);
+										$tableName = str_replace('\\', '&backSlash;' , $tableName);
+									?>
+									<tr><th><a href="hub/thread_name={{ $tableName }}/id={{ $tableInfo['thread_id'] }}">{{$tableInfo['thread_name']}}</a></th><td>{{$tableInfo['created_at']}}</td></tr>
 								@endforeach
 							</tbody>
 						</table>

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -1,7 +1,11 @@
 <x-app-layout>
 	<x-slot name="header">
+		<?php
+			$thread_name = str_replace("&slash;", "/", $thread_name);
+			$thread_name = str_replace("&backSlash;", "\\", $thread_name);
+		?>
 		<h2 class="font-semibold text-xl text-gray-800 leading-tight"> 
-			{{ str_replace("&slash;", "/", $thread_name) }} 
+			{{ $thread_name }} 
 		</h2>
 	</x-slot>
 

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -1,11 +1,11 @@
 <x-app-layout>
 	<x-slot name="header">
 		<?php
-			$thread_name = str_replace("&slash;", "/", $thread_name);
-			$thread_name = str_replace("&backSlash;", "\\", $thread_name);
+			$title = str_replace("&slash;", "/", $thread_name);
+			$title = str_replace("&backSlash;", "\\", $title);
 		?>
 		<h2 class="font-semibold text-xl text-gray-800 leading-tight"> 
-			{{ $thread_name }} 
+			{{ $title }} 
 		</h2>
 	</x-slot>
 
@@ -29,9 +29,10 @@
 					
 					<!-- グローバル変数 -->
 					<script>
-						const url = "{{$url}}";
-						const table = "{{ str_replace('&slash;', '/', $thread_name) }}";
-						const thread_id = "{{$thread_id}}";
+						console.log("{{ $thread_name }}");
+						const url = "{{ $url }}";
+						const table = "{{ $thread_name }}";
+						const thread_id = "{{ $thread_id }}";
 					</script>
 
 					<script>


### PR DESCRIPTION
## 関連

- #67 

## なぜこの変更をするのか

無し

## やったこと

- ハブからURLを生成する際にバックスラッシュを文字列に変換
- スレッドページで文字列からバックスラッシュに変換

## やらないこと

無し

## できるようになること（ユーザ目線）

- スレッド名にバックスラッシュを使用可能になる

## できなくなること（ユーザ目線）

無し

## 動作確認

- バックスラッシュが含まれるスレッド名でスレッド作成．このスレッドで書き込み・いいね機能が正常に動作することを確認

## その他

無し