### PR TITLE
書き込みが無い状態でも，スレッドが存在していれば「スレッドが存在しません」を表示させない

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -17,10 +17,7 @@ class jQuery_ajax extends Controller {
 			$tableName,
 			$request->user()->id
 		);
-		if ($stmt == null) {
-			$stmt['result'] = "NO";
-			return json_encode($stmt);
-		}
+
 		return json_encode($stmt);
 	}
 

--- a/app/Http/Controllers/keizibanCTL.php
+++ b/app/Http/Controllers/keizibanCTL.php
@@ -13,11 +13,16 @@ class keizibanCTL extends Controller {
 			$request->user()->id
 		);
 
+		if ($stmt == 0) {
+			$response['result'] = 0;
+		} else {
+			$response['result'] = 1;
+		}
+
 		$response['thread_name'] = $request->thread_name;
 		$response['thread_id'] = $request->thread_id;
 		$response['username'] = $request->user()->name;
 		$response['url'] = url('/');
-		$response['allRow'] = $stmt;
 		return view('keiziban', $response);
 	}
 }

--- a/app/Http/Middleware/Access_log.php
+++ b/app/Http/Middleware/Access_log.php
@@ -17,12 +17,14 @@ class Access_log
      */
     public function handle(Request $request, Closure $next)
     {
-        $table = $request->thread_id;
+        $thread_name = $request->thread_name;
+        $thread_id = $request->thread_id;
         $user = $request->user()->id;
         $ip = $request->ip();
         $save = new Record_AccessLog;
         $save->func(
-            $table,
+            $thread_name,
+            $thread_id,
             $user,
             $ip
         );

--- a/app/Models/Get.php
+++ b/app/Models/Get.php
@@ -47,7 +47,7 @@ class Get extends Model {
 		if ($exists) {
 			$stmt = DB::connection('mysql_keiziban')->select($sql);
 		} else {
-			$stmt = null;
+			$stmt = 0;
 		}
 		
 		return $stmt;

--- a/app/Models/Record_AccessLog.php
+++ b/app/Models/Record_AccessLog.php
@@ -4,8 +4,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 class Record_AccessLog extends Model {
-    public function func($thread, $user, $ip) {
-        $thread = htmlspecialchars($thread,ENT_QUOTES,"UTF-8");
+    public function func($thread_name, $thread_id, $user, $ip) {
+        $thread_name = htmlspecialchars($thread_name, ENT_QUOTES, "UTF-8");
+        $thread_id = htmlspecialchars($thread_id, ENT_QUOTES, "UTF-8");
 
         $sql= <<<EOF
         INSERT INTO
@@ -14,20 +15,26 @@ class Record_AccessLog extends Model {
                 id,
                 time,
                 user_id,
+                thread_name,
                 thread_id,
                 access_log
             )
             VALUES(
                 NULL,
                 NOW(),
-                :usr_name,
-                '$thread',
+                :user_id,
+                :thread_name,
+                :thread_id,
                 :access_log
             )
         EOF;
         DB::connection('mysql_keiziban')->insert(
-            $sql,
-            [$user, $ip]
+            $sql, [
+                'user_id' => $user, 
+                'thread_name' => $thread_name,
+                'thread_id' => $thread_id,
+                'access_log' => $ip
+            ]
         );
 
         return null;

--- a/database/migrations/2022_05_25_073001_create_access_logs_table.php
+++ b/database/migrations/2022_05_25_073001_create_access_logs_table.php
@@ -17,6 +17,7 @@ class CreateAccessLogsTable extends Migration
             $table->id();
             $table->text('time');
             $table->text('user_id');
+            $table->text('thread_name');
             $table->text('thread_id');
             $table->text('access_log');
         });

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -25,17 +25,13 @@ function reload() {
       "table": thread_id
     }
   }).done(function (data) {
-    if (data['result'] == "NO") {
-      displayArea.innerHTML = "\n            <div class=\"mt-4\">\n                <h1 class=\"text-danger\">\u203B\u30B9\u30EC\u30C3\u30C9\u304C\u5B58\u5728\u3057\u307E\u305B\u3093</h1>\n            </div>";
-    } else {
-      displayArea.innerHTML = "<br>";
+    displayArea.innerHTML = "<br>";
 
-      for (var item in data) {
-        if (data[item]['user_like'] == 1) {
-          displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
-        } else {
-          displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
-        }
+    for (var item in data) {
+      if (data[item]['user_like'] == 1) {
+        displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
+      } else {
+        displayArea.insertAdjacentHTML('afterbegin', data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + data[item]['message'] + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>");
       }
     }
   }).fail(function (XMLHttpRequest, textStatus, errorThrown) {

--- a/resources/js/Get_allRow.js
+++ b/resources/js/Get_allRow.js
@@ -18,35 +18,28 @@ function reload(){
         dataType: "json",
         data: {"table" : thread_id}
     }).done(function (data) {
-        if (data['result'] == "NO") {
-            displayArea.innerHTML = `
-            <div class="mt-4">
-                <h1 class="text-danger">※スレッドが存在しません</h1>
-            </div>`;
-        } else {
-            displayArea.innerHTML = "<br>";
-            for (var item in data) {
-                if (data[item]['user_like'] == 1) {
-                    displayArea.insertAdjacentHTML('afterbegin',
-                    data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + 
-                    "<br>" +
-                    "<p style='overflow-wrap: break-word;'>" +
-                    data[item]['message'] +
-                    "</p>" +
-                    "<br>" +
-                    "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
-                    "<hr>");
-                } else {
-                    displayArea.insertAdjacentHTML('afterbegin',
-                    data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + 
-                    "<br>" +
-                    "<p style='overflow-wrap: break-word;'>" +
-                    data[item]['message'] +
-                    "</p>" +
-                    "<br>" +
-                    "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
-                    "<hr>");
-                }
+        displayArea.innerHTML = "<br>";
+        for (var item in data) {
+            if (data[item]['user_like'] == 1) {
+                displayArea.insertAdjacentHTML('afterbegin',
+                data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + 
+                "<br>" +
+                "<p style='overflow-wrap: break-word;'>" +
+                data[item]['message'] +
+                "</p>" +
+                "<br>" +
+                "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
+                "<hr>");
+            } else {
+                displayArea.insertAdjacentHTML('afterbegin',
+                data[item]['no'] + ": " + data[item]['name'] + " " + data[item]['time'] + 
+                "<br>" +
+                "<p style='overflow-wrap: break-word;'>" +
+                data[item]['message'] +
+                "</p>" +
+                "<br>" +
+                "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['no'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
+                "<hr>");
             }
         }
     }).fail(function (XMLHttpRequest, textStatus, errorThrown) {

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -29,7 +29,6 @@
 					
 					<!-- グローバル変数 -->
 					<script>
-						console.log("{{ $thread_name }}");
 						const url = "{{ $url }}";
 						const table = "{{ $thread_name }}";
 						const thread_id = "{{ $thread_id }}";
@@ -82,27 +81,34 @@
 								<a href="{{ url('/hub') }}">{{__('Go hub')}}</a>
 								<p class="h2">{{$username}}</p>
 							</div> 
-							<br><br>
+							<br>
+							<br>
 
+						@if ($result == 1)
 							<div class="row">
-							<hr>
-							
-							<div class="col-4">
-								<form id="sendMessage">
-									<div class="mb-2">
-										<label class="form-label">コメント</label>
-										<textarea class="form-control" name="message" rows="7"></textarea>
-										<br>
-										<div class="form-text">入力欄の右下にマウスカーソルを移動させると，高さを変えることができます</div>
-										<div id="sendAlertArea"></div>
-									</div>
-								</form>
-								<button id="sendMessageBtn" class="btn btn-primary">{{__('Write forum')}}</button>
+								<hr>
+								<div class="col-4">
+									<form id="sendMessage">
+										<div class="mb-2">
+											<label class="form-label">コメント</label>
+											<textarea class="form-control" name="message" rows="7"></textarea>
+											<br>
+											<div class="form-text">入力欄の右下にマウスカーソルを移動させると，高さを変えることができます</div>
+											<div id="sendAlertArea"></div>
+										</div>
+									</form>
+									<button id="sendMessageBtn" class="btn btn-primary">{{__('Write forum')}}</button>
+								</div>
+
+								<div id="displayArea" class="col-8" style="height:70vh; width: 100% overflow-y:scroll; overflow-x:hidden;"></div>
 							</div>
-
-							<div id="displayArea" class="col-8" style="height:70vh; width: 100% overflow-y:scroll; overflow-x:hidden;"></div>
-
-						</div>
+						@else
+							<div class="mt-4">
+								<h1 class="text-danger">※スレッドが存在しません</h1>
+							</div>
+							<br>
+							<br>
+						@endif
 					</div>
 
 					<div>
@@ -114,7 +120,9 @@
 						></script> 
 						
 						<!-- others -->
-						<script src="{{ mix('js/app_jquery.js') }}"></script>
+						@if ($result == 1)
+							<script src="{{ mix('js/app_jquery.js') }}"></script>
+						@endif
 					</div>
 				</body> 
 				<!-- my area end -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,5 +43,6 @@ Route::middleware([
     Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
     Route::get('hub/thread_name={thread_name}/id={thread_id}', 'App\Http\Controllers\keizibanCTL')->middleware('Access_log')->name('keiziban');
     Route::get('hub/thread_name={thread_name}/id=', 'App\Http\Controllers\keizibanCTL')->middleware('Access_log')->name('keiziban');
+    Route::get('hub/thread_name=/id=', 'App\Http\Controllers\keizibanCTL')->middleware('Access_log')->name('keiziban');
     Route::get('/mypage', 'App\Http\Controllers\MyPage')->name('mypage');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,5 +42,6 @@ Route::middleware([
     Route::get('/dashboard', function () { return view('dashboard'); })->name('dashboard');
     Route::get('/hub', 'App\Http\Controllers\showTablesCTL')->name('hub');
     Route::get('hub/thread_name={thread_name}/id={thread_id}', 'App\Http\Controllers\keizibanCTL')->middleware('Access_log')->name('keiziban');
+    Route::get('hub/thread_name={thread_name}/id=', 'App\Http\Controllers\keizibanCTL')->middleware('Access_log')->name('keiziban');
     Route::get('/mypage', 'App\Http\Controllers\MyPage')->name('mypage');
 });


### PR DESCRIPTION
## 関連

- #62

## なぜこの変更をするのか

無し

## やったこと

- 書き込みが無いスレッドで「スレッドが存在しません」を表示させない
- 以前までの「スレッドが存在しません」表示の判定処理を削除
- `access_logs`テーブルにカラムの追加
- 保存するアクセスログにスレッド名の追加
- URLのスレッド名・スレッドIDが空の状態でも「スレッドが存在しません」を表示させる / 以前は404エラー

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- URLのスレッドIDを編集して，「スレッドが存在しません」が表示される事を確認
- アクセスログにスレッド名が保存される事を確認
- アクセスログでスレッド名・スレッドIDが何もない（URLに）状態でも保存される事を確認

## その他

無し