### PR TITLE
いいね・アクセスしたユーザを特定するためにユーザIDからユーザEmailに保存するものを変更

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -15,7 +15,7 @@ class jQuery_ajax extends Controller {
 		$tableName = $request->post('table');
 		$stmt = $get->allRow(
 			$tableName,
-			$request->user()->id
+			$request->user()->email
 		);
 
 		return json_encode($stmt);
@@ -49,13 +49,13 @@ class jQuery_ajax extends Controller {
 	public function like(Request $request) {
 		$thread_id = $request->thread_id;
 		$message_id = $request->message_id;
-		$user_id = $request->user()->id;
+		$user_email = $request->user()->email;
 
 		$like = new Like;
 		$like->like(
 			$thread_id,
 			$message_id,
-			$user_id
+			$user_email
 		);
 
 		return null;
@@ -64,13 +64,13 @@ class jQuery_ajax extends Controller {
 	public function unlike(Request $request) {
 		$thread_id = $request->thread_id;
 		$message_id = $request->message_id;
-		$user_id = $request->user()->id;
+		$user_email = $request->user()->email;
 
 		$like = new Like;
 		$like->unlike(
 			$thread_id,
 			$message_id,
-			$user_id
+			$user_email
 		);
 		return null;
 	}

--- a/app/Http/Middleware/Access_log.php
+++ b/app/Http/Middleware/Access_log.php
@@ -19,13 +19,13 @@ class Access_log
     {
         $thread_name = $request->thread_name;
         $thread_id = $request->thread_id;
-        $user = $request->user()->id;
+        $user_email = $request->user()->email;
         $ip = $request->ip();
         $save = new Record_AccessLog;
         $save->func(
             $thread_name,
             $thread_id,
-            $user,
+            $user_email,
             $ip
         );
         return $next($request);

--- a/app/Models/Get.php
+++ b/app/Models/Get.php
@@ -17,19 +17,19 @@ class Get extends Model {
 		return $stmt;
 	}
 
-	public function allRow($tableName, $user_id) {
+	public function allRow($tableName, $user_email) {
 		$tableName = htmlspecialchars($tableName,  ENT_QUOTES, 'UTF-8');
 		$sql = <<<EOF
 		SELECT
 			$tableName.*, 
-			COUNT(likes.user_id) AS count_user,
+			COUNT(likes.user_email) AS count_user,
 			COALESCE((
 				SELECT 
 					1 
 				 FROM 
 					likes 
 				WHERE 
-					likes.user_id = $user_id AND 
+					likes.user_email = '$user_email' AND 
 					'$tableName' = likes.thread_id AND 
 					$tableName.no = likes.message_id), 0) 
 					AS user_like

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 class Like extends Model {
-    public function like($thread_id, $message_id, $user_id) {
+    public function like($thread_id, $message_id, $user_email) {
         $thread_id = htmlspecialchars($thread_id, ENT_QUOTES, 'UTF-8');
         
         $query =<<<EOF
@@ -17,7 +17,7 @@ class Like extends Model {
             NULL,
             '$thread_id',
             $message_id,
-            $user_id,
+            '$user_email',
             NOW(),
             NULL
         FROM
@@ -31,7 +31,7 @@ class Like extends Model {
                 WHERE
                     thread_id = :thread_id AND
                     message_id = :message_id AND
-                    user_id = :user_id
+                    user_email = :user_email
             );
         EOF;
         
@@ -39,13 +39,13 @@ class Like extends Model {
             $query, [
                 'thread_id' => $thread_id, 
                 'message_id' => $message_id, 
-                'user_id' => $user_id,
+                'user_email' => $user_email,
             ]
         );
         return null;
     }
 
-    public function unlike($thread_id, $message_id, $user_id) {
+    public function unlike($thread_id, $message_id, $user_email) {
         $thread_id = htmlspecialchars($thread_id, ENT_QUOTES, 'UTF-8');
         
         $query =<<<EOF
@@ -55,7 +55,7 @@ class Like extends Model {
         WHERE
             likes.thread_id = '$thread_id' AND
             likes.message_id = $message_id AND
-            likes.user_id = $user_id
+            likes.user_email = '$user_email'
         EOF;
 
         DB::connection('mysql_keiziban')->delete($query);

--- a/app/Models/Record_AccessLog.php
+++ b/app/Models/Record_AccessLog.php
@@ -13,20 +13,18 @@ class Record_AccessLog extends Model {
         INSERT INTO
         
             access_logs (
-                id,
-                time,
                 user_email,
                 thread_name,
                 thread_id,
-                access_log
+                access_log,
+                created_at
             )
             VALUES(
-                NULL,
-                NOW(),
                 :user_email,
                 :thread_name,
                 :thread_id,
-                :access_log
+                :access_log,
+                NOW()
             )
         EOF;
         DB::connection('mysql_keiziban')->insert(

--- a/app/Models/Record_AccessLog.php
+++ b/app/Models/Record_AccessLog.php
@@ -4,9 +4,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 class Record_AccessLog extends Model {
-    public function func($thread_name, $thread_id, $user, $ip) {
+    public function func($thread_name, $thread_id, $user_email, $ip) {
         $thread_name = htmlspecialchars($thread_name, ENT_QUOTES, "UTF-8");
         $thread_id = htmlspecialchars($thread_id, ENT_QUOTES, "UTF-8");
+        $user_email = htmlspecialchars($user_email, ENT_QUOTES, "UTF-8");
 
         $sql= <<<EOF
         INSERT INTO
@@ -14,7 +15,7 @@ class Record_AccessLog extends Model {
             access_logs (
                 id,
                 time,
-                user_id,
+                user_email,
                 thread_name,
                 thread_id,
                 access_log
@@ -22,7 +23,7 @@ class Record_AccessLog extends Model {
             VALUES(
                 NULL,
                 NOW(),
-                :user_id,
+                :user_email,
                 :thread_name,
                 :thread_id,
                 :access_log
@@ -30,7 +31,7 @@ class Record_AccessLog extends Model {
         EOF;
         DB::connection('mysql_keiziban')->insert(
             $sql, [
-                'user_id' => $user, 
+                'user_email' => $user_email, 
                 'thread_name' => $thread_name,
                 'thread_id' => $thread_id,
                 'access_log' => $ip

--- a/app/Models/create_thread.php
+++ b/app/Models/create_thread.php
@@ -20,9 +20,28 @@ class create_thread extends Model {
     }
 
     public function insertTable($tableName, $thread_id, $user_email) {
+        $query = <<<EOF
+        INSERT INTO
+            hub(
+                thread_id,
+                thread_name,
+                user_email,
+                created_at
+            )
+        VALUES(
+            :thread_id,
+            :thread_name,
+            :user_email,
+            NOW()
+        )
+        EOF;
+
         DB::connection('mysql_keiziban')->insert(
-        "INSERT INTO hub(id, thread_id, thread_name, user_email, created_at) VALUES(NULL, :thread_id, :thread_name, :user_email, NOW())", 
-        [$thread_id, $tableName, $user_email]);
+        $query, [
+            'thread_id' => $thread_id, 
+            'thread_name' => $tableName, 
+            'user_email' => $user_email
+        ]);
         return null;
     }
 }

--- a/database/migrations/2022_05_05_112244_create_hub_table.php
+++ b/database/migrations/2022_05_05_112244_create_hub_table.php
@@ -18,7 +18,7 @@ class CreateHubTable extends Migration
             $table->string('thread_id');
             $table->string('thread_name');
             $table->string('user_email');
-            $table->string('created_at');
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2022_05_09_134146_create_likes_table.php
+++ b/database/migrations/2022_05_09_134146_create_likes_table.php
@@ -17,7 +17,7 @@ class CreateLikesTable extends Migration
             $table->id();
             $table->string('thread_id');
             $table->integer('message_id')->unsigned();
-            $table->integer('user_id')->unsigned();
+            $table->string('user_email');
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_05_25_073001_create_access_logs_table.php
+++ b/database/migrations/2022_05_25_073001_create_access_logs_table.php
@@ -16,7 +16,7 @@ class CreateAccessLogsTable extends Migration
         Schema::connection('mysql_keiziban')->create('access_logs', function (Blueprint $table) {
             $table->id();
             $table->text('time');
-            $table->text('user_id');
+            $table->text('user_email');
             $table->text('thread_name');
             $table->text('thread_id');
             $table->text('access_log');

--- a/database/migrations/2022_05_25_073001_create_access_logs_table.php
+++ b/database/migrations/2022_05_25_073001_create_access_logs_table.php
@@ -15,11 +15,11 @@ class CreateAccessLogsTable extends Migration
     {
         Schema::connection('mysql_keiziban')->create('access_logs', function (Blueprint $table) {
             $table->id();
-            $table->text('time');
-            $table->text('user_email');
+            $table->string('user_email');
             $table->text('thread_name');
             $table->text('thread_id');
-            $table->text('access_log');
+            $table->string('access_log');
+            $table->timestamps();
         });
     }
 


### PR DESCRIPTION
## 関連

- #75 
- #76 

## なぜこの変更をするのか

無し

## やったこと

- アクセスログで保存するものをユーザIDからユーザEmailに変更
- いいねで保存するものをユーザIDからユーザEmailに変更
- hubテーブルのカラムを`timestamp`に
- hubテーブルレコード追加のクエリを見やすく書き換え
- likesテーブルのカラムの文字列がある程度決まっているものは`text`から`string`に型変更
- likesテーブルのカラムの`time`を`timestamp`に変更

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- アクセスログにユーザEmailが保存される事を確認
- いいねテーブルにユーザEmailが保存される事を確認
- スレッドを新規作成出来る事を確認
- スレッドに書き込み出来る事を確認
- いいねボタンが押せる事を確認
- いいねの取り消しが出来る事を確認

## その他

無し