### PR TITLE
推奨拡張機能のポップアップを表示させる

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "editor.formatOnType": true,
     "files.associations": {
         "*.blade.php": "html"
-    }
+    },
+    "extensions.ignoreRecommendations": false
 }


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- vscodeの推奨拡張機能のポップアップを強制的に表示させるため

## やったこと

- .vscode/settings.json  個人設定を上書き

## やらないこと

なし

## できるようになること（ユーザ目線）

- 設定をtrueにしている場合でも表示される

## できなくなること（ユーザ目線）

なし

## 動作確認

開発用サーバーと個人のvscode

## その他

なし