### PR TITLE
ページテーマ用にユーザテーブルにカラム追加

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -11,7 +11,6 @@ use App\Models\create_thread;
 use App\Models\Like;
 use App\Models\AdminActions;
 use App\Models\User;
-use Illuminate\Support\Facades\Log;
 
 class jQuery_ajax extends Controller
 {

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -10,6 +10,8 @@ use App\Models\Send;
 use App\Models\create_thread;
 use App\Models\Like;
 use App\Models\AdminActions;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 class jQuery_ajax extends Controller
 {
@@ -124,6 +126,17 @@ class jQuery_ajax extends Controller
 
         $admin_actions = new AdminActions;
         $admin_actions->restore_message_record($thread_id, $message_id);
+
+        return null;
+    }
+
+    public function page_thema(Request $request)
+    {
+        $page_thema = $request->page_thema;
+        $user = User::find($request->user()->id);
+
+        $user->thema = $page_thema;
+        $user->save();
 
         return null;
     }

--- a/app/Http/Middleware/IsAdmin.php
+++ b/app/Http/Middleware/IsAdmin.php
@@ -16,7 +16,7 @@ class IsAdmin
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($request->user()->is_admin) {
+        if ($request->user()->is_admin == 1) {
             return $next($request);
         } else {
             abort(403);

--- a/app/Models/UserPageThemas.php
+++ b/app/Models/UserPageThemas.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserPageThemas extends Model
+{
+    protected $connection = 'mysql';
+    protected $table = 'user_page_themas';
+}

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->boolean('is_admin')->default(false);
+            $table->boolean('is_admin')->unsigned()->default(0);
             $table->rememberToken();
             $table->foreignId('current_team_id')->nullable();
             $table->string('profile_photo_path', 2048)->nullable();

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->boolean('is_admin')->unsigned()->default(0);
+            $table->boolean('thema')->unsigned()->default(0);
             $table->rememberToken();
             $table->foreignId('current_team_id')->nullable();
             $table->string('profile_photo_path', 2048)->nullable();

--- a/database/migrations/2022_06_17_115624_create_user_page_themas_table.php
+++ b/database/migrations/2022_06_17_115624_create_user_page_themas_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserPageThemasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_page_themas', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('thema_id')->unsigned()->unique();
+            $table->string('thema_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_page_themas');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\UserPageThemas;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,7 +14,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
         $this->call(AdminInstallSeeder::class);
+        $this->call(UserPageThemasSeeder::class);
     }
 }

--- a/database/seeders/UserPageThemasSeeder.php
+++ b/database/seeders/UserPageThemasSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\UserPageThemas;
+
+class UserPageThemasSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        UserPageThemas::create([
+            'thema_id' => 0,
+            'thema_name' => 'default'
+        ]);
+
+        UserPageThemas::create([
+            'thema_id' => 1,
+            'thema_name' => 'dark'
+        ]);
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1097,9 +1097,6 @@ select {
 .block {
   display: block;
 }
-.inline {
-  display: inline;
-}
 .flex {
   display: flex;
 }

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -250,5 +250,40 @@ $('#restore_messageBtn').click(function () {
 });
 })();
 
+// This entry need to be wrapped in an IIFE because it need to be isolated against other entry modules.
+(() => {
+/*!*****************************************!*\
+  !*** ./resources/js/SelectPageThema.js ***!
+  \*****************************************/
+$('#page_thema').change(function () {
+  var value = $('option:selected').val();
+
+  if (value == '') {
+    return;
+  } else if (value == 'default') {
+    value = 0;
+  } else if (value == 'dark') {
+    value = 1;
+  }
+
+  $.ajaxSetup({
+    headers: {
+      'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+    }
+  });
+  $.ajax({
+    type: "POST",
+    url: url + "/jQuery.ajax/page_thema",
+    data: {
+      "page_thema": value
+    }
+  }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+    console.log(XMLHttpRequest.status);
+    console.log(textStatus);
+    console.log(errorThrown.message);
+  });
+});
+})();
+
 /******/ })()
 ;

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -277,7 +277,9 @@ $('#page_thema').change(function () {
     data: {
       "page_thema": value
     }
-  }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+  }).done(function () {
+    window.location.reload();
+  }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
     console.log(XMLHttpRequest.status);
     console.log(textStatus);
     console.log(errorThrown.message);

--- a/resources/js/SelectPageThema.js
+++ b/resources/js/SelectPageThema.js
@@ -1,0 +1,30 @@
+$('#page_thema').change(function () {
+    var value = $('option:selected').val();
+
+    if (value == '') {
+        return;
+    } else if (value == 'default') {
+        value = 0;
+    } else if (value == 'dark') {
+        value = 1;
+    }
+
+    $.ajaxSetup({
+        headers: {
+            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+        }
+    });
+
+    $.ajax({
+        type: "POST",
+        url: url + "/jQuery.ajax/page_thema",
+        data: {
+            "page_thema": value
+        },
+    }).done(function () {
+    }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+        console.log(XMLHttpRequest.status);
+        console.log(textStatus);
+        console.log(errorThrown.message);
+    });
+})

--- a/resources/js/SelectPageThema.js
+++ b/resources/js/SelectPageThema.js
@@ -22,6 +22,7 @@ $('#page_thema').change(function () {
             "page_thema": value
         },
     }).done(function () {
+        window.location.reload();
     }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
         console.log(XMLHttpRequest.status);
         console.log(textStatus);

--- a/resources/views/MyPage.blade.php
+++ b/resources/views/MyPage.blade.php
@@ -27,6 +27,16 @@
                     <option value="dark">ダークテーマ</option>
                 </select>
 
+                <!-- ここからテーマ取得例（不要になり次第削除） -->
+                <br>
+                <br>
+                @if (Auth::user()->thema == 0)
+                デフォルトテーマ
+                @elseif (Auth::user()->thema == 1)
+                ダークテーマ
+                @endif
+                <!-- ここまでテーマ取得例（不要になり次第削除） -->
+
                 <!-- デザイン関係なし -->
                 <!-- jQuery -->
                 <script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>

--- a/resources/views/MyPage.blade.php
+++ b/resources/views/MyPage.blade.php
@@ -18,6 +18,25 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
 
+                <meta name="csrf-token" content="{{ csrf_token() }}" />
+
+                <p>ページテーマ</p>
+                <select id="page_thema">
+                    <option value="">選択して下さい</option>
+                    <option value="default">デフォルト</option>
+                    <option value="dark">ダークテーマ</option>
+                </select>
+
+                <!-- デザイン関係なし -->
+                <!-- jQuery -->
+                <script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
+
+                <script src="{{ mix('js/app_jquery.js') }}"></script>
+                <script>
+                    const url = "{{ url('/') }}";
+                </script>
+                <!-- デザイン関係なし -->
+
             </div>
         </div>
     </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -9,15 +9,7 @@
     <!-- ここからタイトル（ページのヘッダでなはい） -->
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-
-            @if (!Auth::user()->is_admin)
-            <!-- 一般ユーザのみに表示 -->
             {{ __("Top page") }}
-            @else
-            <!-- 管理者ユーザのみに表示 -->
-            管理者用ページ
-            @endif
-
         </h2>
     </x-slot>
     <!-- ここまでタイトル（ページのヘッダではない） -->

--- a/resources/views/hub.blade.php
+++ b/resources/views/hub.blade.php
@@ -44,7 +44,7 @@
                         <br /><br />
 
                         <!-- ここから管理者のみに表示 -->
-                        @if (Auth::user()->is_admin)
+                        @if (Auth::user()->is_admin == 1)
                         <form id="thread_actions_form">
                             <label class="form-label">対象：スレッドID</label>
                             <input id="thread_id" class="form-control" type="text" />
@@ -85,7 +85,7 @@
                                         <td>{{ __("Create time") }}</td>
 
                                         <!-- ここから管理者のみに表示 -->
-                                        @if (Auth::user()->is_admin)
+                                        @if (Auth::user()->is_admin == 1)
                                         <td>
                                             {{ __("Thread ID") }}
                                         </td>
@@ -117,7 +117,7 @@
                                         </td>
 
                                         <!-- ここから管理者のみに表示 -->
-                                        @if (Auth::user()->is_admin)
+                                        @if (Auth::user()->is_admin == 1)
                                         <td>
                                             {{ $tableInfo["thread_id"] }}
                                         </td>
@@ -134,7 +134,7 @@
 
                     <!-- ここから管理者のみに表示 -->
                     <!-- Modal -->
-                    @if (Auth::user()->is_admin)
+                    @if (Auth::user()->is_admin == 1)
                     <div class="modal fade" id="DeleteThreadModal" tabindex="-1"
                         aria-labelledby="DeleteThreadModalLabel" aria-hidden="true">
                         <div class="modal-dialog modal-dialog-centered">

--- a/resources/views/keiziban.blade.php
+++ b/resources/views/keiziban.blade.php
@@ -115,7 +115,7 @@
                             <div class="col-sm-4 col-xs-12">
 
                                 <!-- ここから管理者のみに表示 -->
-                                @if (Auth::user()->is_admin)
+                                @if (Auth::user()->is_admin == 1)
                                 <form id="message_actions_form">
                                     <div class="mb-2">
                                         <label class="form-label">対象：コメントID</label>
@@ -192,7 +192,7 @@
 
                     <!-- ここから管理者のみに表示 -->
                     <!-- Modal -->
-                    @if (Auth::user()->is_admin)
+                    @if (Auth::user()->is_admin == 1)
                     <div class="modal fade" id="DeleteMessageModal" tabindex="-1"
                         aria-labelledby="DeleteMessageModalLabel" aria-hidden="true">
                         <div class="modal-dialog modal-dialog-centered">

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -20,13 +20,7 @@
                 <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                     <x-jet-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')"
                         class="text-decoration-none">
-                        @if (!Auth::user()->is_admin)
-                        <!-- 一般ユーザのみに表示 -->
                         {{__('Top page')}}
-                        @else
-                        <!-- 管理者ユーザのみに表示 -->
-                        管理者用ページ
-                        @endif
                     </x-jet-nav-link>
                     <x-jet-nav-link href="{{ route('hub') }}" :active="request()->routeIs('hub')"
                         class="text-decoration-none">

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::middleware([
     Route::match(['get', 'post'], 'jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
     Route::match(['get', 'post'], 'jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
     Route::match(['get', 'post'], 'jQuery.ajax/unlike', "App\Http\Controllers\jQuery_ajax@unlike");
+    Route::match(['get', 'post'], 'jQuery.ajax/page_thema', "App\Http\Controllers\jQuery_ajax@page_thema");
 
     // 管理者ユーザのみ
     Route::middleware([

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -20,7 +20,8 @@ mix.js('resources/js/app.js', 'public/js')
         'resources/js/Delete_thread',
         'resources/js/Edit_thread',
         'resources/js/Delete_message',
-        'resources/js/Restore_message'
+        'resources/js/Restore_message',
+        'resources/js/SelectPageThema'
     ], 'public/js/app_jquery.js')
     .postCss('resources/css/app.css', 'public/css', [
         require('postcss-import'),


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

ユーザごとに異なるテーマでページ表示を可能にするため

## やったこと

- `is_admin`カラムの不具合予備軍の修正
- ユーザテーブルに表示テーマ用カラム追加
- ユーザの表示テーマ変更手段をマイページに追加

## やらないこと

- テーマカラムを利用してデザインはこのプルリクではやらない

## できるようになること（ユーザ目線）

- マイページでテーマカラムを変更できる

## できなくなること（ユーザ目線）

無し

## 動作確認

- 複数ユーザで異なるテーマを設定出来る事を確認
- マイページにテーマ変更用の箇所があり，そこからテーマ変更出来る事を確認

## その他

無し