### PR TITLE
GitHub Actionsで不要なデータベースの作成をしないように

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -19,7 +19,6 @@ jobs:
           - 3306:3306
         env:
           MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: main
         options: >-
           --health-cmd "mysqladmin ping"
           --health-interval 10s
@@ -39,10 +38,9 @@ jobs:
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
       - name: Create Database
-        run: mysql --protocol=tcp -h localhost -P 3306 -u root -ppassword -e "CREATE DATABASE forum"
+        run: mysql --protocol=tcp -h localhost -P 3306 -u root -ppassword -e "CREATE DATABASE main"
       - name: Execute tests (Unit and Feature tests) via PHPUnit
         env:
           DB_DATABASE: main
-          DB_DATABASE_KEIZIBAN: forum
           DB_PASSWORD: password
         run: vendor/bin/phpunit


### PR DESCRIPTION
## 関連

なし

## なぜこの変更をするのか

- 行う処理を減らすことで速度の高速化ができるかな〜？と思いまして

## やったこと

- 使わなくなった2つ目のデータベースに関する処理を削除

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- フォーク先リポジトリのGithub Actionsでテストが正常に動作することを確認

## その他

なし