### PR TITLE
スレッドに画像のアップロード機能追加

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -152,8 +152,9 @@ class jQuery_ajax extends Controller
             "\t" => "&ensp;&ensp;"
         );
 
+        $message = $request->message;
         foreach ($special_character_set as $key => $value) {
-            $message = str_replace($key, $value, $request->message);
+            $message = str_replace($key, $value, $message);
         }
 
         $thread = Hub::where('thread_id', '=', $request->table)->first();

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -12,9 +12,11 @@ use App\Models\User;
 use App\Models\Hub;
 use App\Models\ThreadCategorys;
 use App\Models\Likes;
+use App\Models\ThreadImagePaths;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class jQuery_ajax extends Controller
 {
@@ -233,6 +235,43 @@ class jQuery_ajax extends Controller
             default:
                 break;
         }
+    }
+
+    public function img_upload(Request $request)
+    {
+        Log::debug($request->all());
+        Log::debug($request->post('thread_id'));
+        Log::debug($request->thread_id);
+        Log::debug($request->file('img')->store('img/thread_message', 'public'));
+
+        /*
+        // 画像情報があれば，保存処理を実行
+        if ($request->file('img') != null) {
+            $img = $request->img;
+            Log::debug($img);
+            Log::debug($request->file('img')->store('img', 'public'));
+
+            $size = $img->getSize();
+            $path = $img->store('img', 'public');
+
+            // 画像サイズが1MB以下かどうか（js時点でバリデーション出来ているはずだけど一応）
+            if (1048576 <= $size) {
+                abort(400);
+                return;
+            }
+
+            // store処理が実行出来ればDBにPathなどを保存
+            if ($path) {
+                ThreadImagePaths::create([
+                    'thread_id' => $request->thread_id,
+                    'message_id' => $request->message_id,
+                    'user_email' => $request->user()->email,
+                    'img_path' => $path,
+                    'img_size' => $size
+                ]);
+            }
+        }
+        */
     }
 
     public function create_thread(Request $request)

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -254,7 +254,7 @@ class jQuery_ajax extends Controller
 
         // 画像情報があれば，保存処理を実行
         if ($request->file('img')) {
-            $img = Image::make($request->file('img'))->encode('jpg')->save();
+            $img = Image::make($request->file('img'))->encode('jpg')->orientate()->save();
 
             $size = $img->filesize();
             $path = 'public/images/thread_message/' . str_replace('-', '', Str::uuid()) . '.jpg';

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -16,6 +16,8 @@ use App\Models\ThreadImagePaths;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
+use Intervention\Image\Facades\Image;
+use Illuminate\Support\Facades\Storage;
 
 class jQuery_ajax extends Controller
 {
@@ -252,9 +254,11 @@ class jQuery_ajax extends Controller
 
         // 画像情報があれば，保存処理を実行
         if ($request->file('img')) {
-            $img = $request->file('img');
-            $size = $img->getSize();
-            $path = $img->store('img/thread_messages', 'public');
+            $img = Image::make($request->file('img'))->encode('jpg')->save();
+
+            $size = $img->filesize();
+            $path = 'public/images/thread_message/' . str_replace('-', '', Str::uuid()) . '.jpg';
+            Storage::put($path, $img);
 
             // store処理が実行出来ればDBにPathなどを保存
             if ($path) {
@@ -266,6 +270,8 @@ class jQuery_ajax extends Controller
                     'img_size' => $size
                 ]);
             }
+
+            $img->destroy();
         }
     }
 

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -29,7 +29,6 @@ class jQuery_ajax extends Controller
 
         $thread = Hub::where('thread_id', '=', $this->thread_id)->first();
 
-
         switch ($thread->thread_category_type) {
             case '学科':
                 return DepartmentThreads::select(
@@ -159,13 +158,14 @@ class jQuery_ajax extends Controller
         }
 
         $thread = Hub::where('thread_id', '=', $request->table)->first();
+        $message_id = 0;
 
         switch ($thread->thread_category_type) {
             case '学科':
-                $message_id = DepartmentThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
+                $message_id = DepartmentThreads::where('thread_id', '=', $request->table)->max('message_id') + 1 ?? 0;
                 DepartmentThreads::create([
                     'thread_id' => $request->table,
-                    'message_id' => $message_id + 1,
+                    'message_id' => $message_id,
                     'user_name' => $request->user()->name,
                     'user_email' => $request->user()->email,
                     'message' => $message
@@ -173,10 +173,10 @@ class jQuery_ajax extends Controller
                 break;
 
             case '学年':
-                $message_id = CollegeYearThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
+                $message_id = CollegeYearThreads::where('thread_id', '=', $request->table)->max('message_id') + 1 ?? 0;
                 CollegeYearThreads::create([
                     'thread_id' => $request->table,
-                    'message_id' => $message_id + 1,
+                    'message_id' => $message_id,
                     'user_name' => $request->user()->name,
                     'user_email' => $request->user()->email,
                     'message' => $message
@@ -184,10 +184,10 @@ class jQuery_ajax extends Controller
                 break;
 
             case '部活':
-                $message_id = ClubThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
+                $message_id = ClubThreads::where('thread_id', '=', $request->table)->max('message_id') + 1 ?? 0;
                 ClubThreads::create([
                     'thread_id' => $request->table,
-                    'message_id' => $message_id + 1,
+                    'message_id' => $message_id,
                     'user_name' => $request->user()->name,
                     'user_email' => $request->user()->email,
                     'message' => $message
@@ -195,10 +195,10 @@ class jQuery_ajax extends Controller
                 break;
 
             case '授業':
-                $message_id = LectureThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
+                $message_id = LectureThreads::where('thread_id', '=', $request->table)->max('message_id') + 1 ?? 0;
                 LectureThreads::create([
                     'thread_id' => $request->table,
-                    'message_id' => $message_id + 1,
+                    'message_id' => $message_id,
                     'user_name' => $request->user()->name,
                     'user_email' => $request->user()->email,
                     'message' => $message
@@ -206,10 +206,10 @@ class jQuery_ajax extends Controller
                 break;
 
             case '就職':
-                $message_id = JobHuntingThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
+                $message_id = JobHuntingThreads::where('thread_id', '=', $request->table)->max('message_id') + 1 ?? 0;
                 JobHuntingThreads::create([
                     'thread_id' => $request->table,
-                    'message_id' => $message_id + 1,
+                    'message_id' => $message_id,
                     'user_name' => $request->user()->name,
                     'user_email' => $request->user()->email,
                     'message' => $message
@@ -219,29 +219,7 @@ class jQuery_ajax extends Controller
             default:
                 break;
         }
-    }
 
-    public function img_upload(Request $request)
-    {
-        $thread = Hub::where('thread_id', '=', $request->thread_id)->first();
-        $message_id = 0;
-        switch ($thread->thread_category_type) {
-            case '学科':
-                $message_id = DepartmentThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
-                break;
-            case '学年':
-                $message_id = CollegeYearThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
-                break;
-            case '部活':
-                $message_id = ClubThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
-                break;
-            case '授業':
-                $message_id = LectureThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
-                break;
-            case '就職':
-                $message_id = JobHuntingThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
-                break;
-        }
         // 画像情報があれば，保存処理を実行
         if ($request->file('img')) {
             $img = $request->file('img');
@@ -257,7 +235,7 @@ class jQuery_ajax extends Controller
             // store処理が実行出来ればDBにPathなどを保存
             if ($path) {
                 ThreadImagePaths::create([
-                    'thread_id' => $request->thread_id,
+                    'thread_id' => $request->table,
                     'message_id' => $message_id,
                     'user_email' => $request->user()->email,
                     'img_path' => $path,

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -16,7 +16,6 @@ use App\Models\ThreadImagePaths;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class jQuery_ajax extends Controller
 {
@@ -163,10 +162,7 @@ class jQuery_ajax extends Controller
 
         switch ($thread->thread_category_type) {
             case '学科':
-                $message_id = DepartmentThreads::where('thread_id', '=', $request->table)->max('message_id');
-                if ($message_id == NULL) {
-                    $message_id = 0;
-                }
+                $message_id = DepartmentThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
                 DepartmentThreads::create([
                     'thread_id' => $request->table,
                     'message_id' => $message_id + 1,
@@ -177,10 +173,7 @@ class jQuery_ajax extends Controller
                 break;
 
             case '学年':
-                $message_id = CollegeYearThreads::where('thread_id', '=', $request->table)->max('message_id');
-                if ($message_id == NULL) {
-                    $message_id = 0;
-                }
+                $message_id = CollegeYearThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
                 CollegeYearThreads::create([
                     'thread_id' => $request->table,
                     'message_id' => $message_id + 1,
@@ -191,10 +184,7 @@ class jQuery_ajax extends Controller
                 break;
 
             case '部活':
-                $message_id = ClubThreads::where('thread_id', '=', $request->table)->max('message_id');
-                if ($message_id == NULL) {
-                    $message_id = 0;
-                }
+                $message_id = ClubThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
                 ClubThreads::create([
                     'thread_id' => $request->table,
                     'message_id' => $message_id + 1,
@@ -205,10 +195,7 @@ class jQuery_ajax extends Controller
                 break;
 
             case '授業':
-                $message_id = LectureThreads::where('thread_id', '=', $request->table)->max('message_id');
-                if ($message_id == NULL) {
-                    $message_id = 0;
-                }
+                $message_id = LectureThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
                 LectureThreads::create([
                     'thread_id' => $request->table,
                     'message_id' => $message_id + 1,
@@ -219,10 +206,7 @@ class jQuery_ajax extends Controller
                 break;
 
             case '就職':
-                $message_id = JobHuntingThreads::where('thread_id', '=', $request->table)->max('message_id');
-                if ($message_id == NULL) {
-                    $message_id = 0;
-                }
+                $message_id = JobHuntingThreads::where('thread_id', '=', $request->table)->max('message_id') ?? 0;
                 JobHuntingThreads::create([
                     'thread_id' => $request->table,
                     'message_id' => $message_id + 1,
@@ -239,20 +223,30 @@ class jQuery_ajax extends Controller
 
     public function img_upload(Request $request)
     {
-        Log::debug($request->all());
-        Log::debug($request->post('thread_id'));
-        Log::debug($request->thread_id);
-        Log::debug($request->file('img')->store('img/thread_message', 'public'));
-
-        /*
+        $thread = Hub::where('thread_id', '=', $request->thread_id)->first();
+        $message_id = 0;
+        switch ($thread->thread_category_type) {
+            case '学科':
+                $message_id = DepartmentThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
+                break;
+            case '学年':
+                $message_id = CollegeYearThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
+                break;
+            case '部活':
+                $message_id = ClubThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
+                break;
+            case '授業':
+                $message_id = LectureThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
+                break;
+            case '就職':
+                $message_id = JobHuntingThreads::where('thread_id', '=', $request->thread_id)->max('message_id');
+                break;
+        }
         // 画像情報があれば，保存処理を実行
-        if ($request->file('img') != null) {
-            $img = $request->img;
-            Log::debug($img);
-            Log::debug($request->file('img')->store('img', 'public'));
-
+        if ($request->file('img')) {
+            $img = $request->file('img');
             $size = $img->getSize();
-            $path = $img->store('img', 'public');
+            $path = $img->store('img/thread_messages', 'public');
 
             // 画像サイズが1MB以下かどうか（js時点でバリデーション出来ているはずだけど一応）
             if (1048576 <= $size) {
@@ -264,14 +258,13 @@ class jQuery_ajax extends Controller
             if ($path) {
                 ThreadImagePaths::create([
                     'thread_id' => $request->thread_id,
-                    'message_id' => $request->message_id,
+                    'message_id' => $message_id,
                     'user_email' => $request->user()->email,
                     'img_path' => $path,
                     'img_size' => $size
                 ]);
             }
         }
-        */
     }
 
     public function create_thread(Request $request)

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -256,12 +256,6 @@ class jQuery_ajax extends Controller
             $size = $img->getSize();
             $path = $img->store('img/thread_messages', 'public');
 
-            // 画像サイズが1MB以下かどうか（js時点でバリデーション出来ているはずだけど一応）
-            if (1048576 <= $size) {
-                abort(400);
-                return;
-            }
-
             // store処理が実行出来ればDBにPathなどを保存
             if ($path) {
                 ThreadImagePaths::create([

--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -34,7 +34,8 @@ class jQuery_ajax extends Controller
                 return DepartmentThreads::select(
                     'department_threads.*',
                     DB::raw('COUNT(likes1.user_email) AS count_user'),
-                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like')
+                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                    'thread_image_paths.img_path'
                 )
                     ->leftjoin('likes AS likes1', function ($join) {
                         $join
@@ -47,6 +48,11 @@ class jQuery_ajax extends Controller
                             ->where('likes2.user_email', '=', $this->user_email)
                             ->whereColumn('likes2.message_id', '=', 'department_threads.message_id');
                     })
+                    ->leftjoin('thread_image_paths', function ($join) {
+                        $join
+                            ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.thread_id')
+                            ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
+                    })
                     ->where('department_threads.thread_id', '=', $this->thread_id)
                     ->groupBy('department_threads.message_id')
                     ->get();
@@ -55,7 +61,8 @@ class jQuery_ajax extends Controller
                 return CollegeYearThreads::select(
                     'college_year_threads.*',
                     DB::raw('COUNT(likes1.user_email) AS count_user'),
-                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like')
+                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                    'thread_image_paths.img_path'
                 )
                     ->leftjoin('likes AS likes1', function ($join) {
                         $join
@@ -68,6 +75,11 @@ class jQuery_ajax extends Controller
                             ->where('likes2.user_email', '=', $this->user_email)
                             ->whereColumn('likes2.message_id', '=', 'college_year_threads.message_id');
                     })
+                    ->leftjoin('thread_image_paths', function ($join) {
+                        $join
+                            ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.thread_id')
+                            ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
+                    })
                     ->where('college_year_threads.thread_id', '=', $this->thread_id)
                     ->groupBy('college_year_threads.message_id')
                     ->get();
@@ -76,7 +88,8 @@ class jQuery_ajax extends Controller
                 return ClubThreads::select(
                     'club_threads.*',
                     DB::raw('COUNT(likes1.user_email) AS count_user'),
-                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like')
+                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                    'thread_image_paths.img_path'
                 )
                     ->leftjoin('likes AS likes1', function ($join) {
                         $join
@@ -89,6 +102,11 @@ class jQuery_ajax extends Controller
                             ->where('likes2.user_email', '=', $this->user_email)
                             ->whereColumn('likes2.message_id', '=', 'club_threads.message_id');
                     })
+                    ->leftjoin('thread_image_paths', function ($join) {
+                        $join
+                            ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.thread_id')
+                            ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
+                    })
                     ->where('club_threads.thread_id', '=', $this->thread_id)
                     ->groupBy('club_threads.message_id')
                     ->get();
@@ -97,7 +115,8 @@ class jQuery_ajax extends Controller
                 return LectureThreads::select(
                     'lecture_threads.*',
                     DB::raw('COUNT(likes1.user_email) AS count_user'),
-                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like')
+                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                    'thread_image_paths.img_path'
                 )
                     ->leftjoin('likes AS likes1', function ($join) {
                         $join
@@ -110,6 +129,11 @@ class jQuery_ajax extends Controller
                             ->where('likes2.user_email', '=', $this->user_email)
                             ->whereColumn('likes2.message_id', '=', 'lecture_threads.message_id');
                     })
+                    ->leftjoin('thread_image_paths', function ($join) {
+                        $join
+                            ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.thread_id')
+                            ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
+                    })
                     ->where('lecture_threads.thread_id', '=', $this->thread_id)
                     ->groupBy('lecture_threads.message_id')
                     ->get();
@@ -118,7 +142,8 @@ class jQuery_ajax extends Controller
                 return JobHuntingThreads::select(
                     'job_hunting_threads.*',
                     DB::raw('COUNT(likes1.user_email) AS count_user'),
-                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like')
+                    DB::raw('COALESCE((likes2.user_email), 0) AS user_like'),
+                    'thread_image_paths.img_path'
                 )
                     ->leftjoin('likes AS likes1', function ($join) {
                         $join
@@ -130,6 +155,11 @@ class jQuery_ajax extends Controller
                             ->where('likes2.thread_id', '=', $this->thread_id)
                             ->where('likes2.user_email', '=', $this->user_email)
                             ->whereColumn('likes2.message_id', '=', 'job_hunting_threads.message_id');
+                    })
+                    ->leftjoin('thread_image_paths', function ($join) {
+                        $join
+                            ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.thread_id')
+                            ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
                     })
                     ->where('job_hunting_threads.thread_id', '=', $this->thread_id)
                     ->groupBy('job_hunting_threads.message_id')

--- a/app/Models/AccessLogs.php
+++ b/app/Models/AccessLogs.php
@@ -50,7 +50,7 @@ class AccessLogs extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 }

--- a/app/Models/AdminMenu.php
+++ b/app/Models/AdminMenu.php
@@ -43,7 +43,7 @@ class AdminMenu extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 }

--- a/app/Models/Hub.php
+++ b/app/Models/Hub.php
@@ -51,7 +51,7 @@ class Hub extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 }

--- a/app/Models/Likes.php
+++ b/app/Models/Likes.php
@@ -49,7 +49,7 @@ class Likes extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 }

--- a/app/Models/ThreadCategorys.php
+++ b/app/Models/ThreadCategorys.php
@@ -39,7 +39,7 @@ class ThreadCategorys extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 }

--- a/app/Models/ThreadImagePaths.php
+++ b/app/Models/ThreadImagePaths.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ThreadImagePaths extends Model
+{
+    use HasFactory;
+
+    /**
+     * Database to be connected
+     *
+     * @var string
+     */
+    protected $connection = 'mysql';
+
+    /**
+     * Tables to be associated
+     *
+     * @var string
+     */
+    protected $table = 'thread_image_paths';
+
+    /**
+     * The attributes that are mass assignable
+     *
+     * @var string[]
+     */
+    protected $fillable = [
+        'thread_id',
+        'message_id',
+        'user_email',
+        'img_path',
+        'img_size',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'thread_id',
+        'img_path',
+        'img_size'
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => 'datetime',
+        'update_at' => 'datetime',
+    ];
+}

--- a/app/Models/UserPageThemas.php
+++ b/app/Models/UserPageThemas.php
@@ -39,7 +39,7 @@ class UserPageThemas extends Model
      * @var array
      */
     protected $casts = [
-        'created_at' => 'datetime',
-        'update_at' => 'datetime',
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "fruitcake/laravel-cors": "^2.0",
         "goldspecdigital/laravel-eloquent-uuid": "^8.0",
         "guzzlehttp/guzzle": "^7.0.1",
+        "intervention/image": "^2.7",
         "laravel-lang/lang": "~8.0",
         "laravel/framework": "^8.75",
         "laravel/jetstream": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e52695fa09c90163b34d5e2d209380f2",
+    "content-hash": "ae2f554ff964bd3d1ef4440cdd917342",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1538,6 +1538,90 @@
                 }
             ],
             "time": "2022-03-20T21:55:58+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/04be355f8d6734c826045d02a1079ad658322dad",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-21T17:30:32+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports "GD Library" and "Imagick" to process images
+    | internally. You may choose one of them according to your PHP
+    | configuration. By default PHP's "GD Library" implementation is used.
+    |
+    | Supported: "gd", "imagick"
+    |
+    */
+
+    'driver' => 'gd'
+
+];

--- a/database/migrations/2022_07_09_111745_create_thread_image_paths_table.php
+++ b/database/migrations/2022_07_09_111745_create_thread_image_paths_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateThreadImagePathsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('thread_image_paths', function (Blueprint $table) {
+            $table->id();
+            $table->string('thread_id');
+            $table->string('message_id');
+            $table->string('user_email');
+            $table->string('img_path');
+            $table->integer('img_size');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('thread_image_paths');
+    }
+}

--- a/database/migrations/2022_07_16_061648_change_unique_img_path_to_thread_image_paths_table.php
+++ b/database/migrations/2022_07_16_061648_change_unique_img_path_to_thread_image_paths_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeUniqueImgPathToThreadImagePathsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->unique(['img_path']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('thread_image_paths', function (Blueprint $table) {
+            $table->dropUnique(['img_path']);
+        });
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1000,6 +1000,9 @@ select {
 .right-0 {
   right: 0px;
 }
+.top-0 {
+  top: 0px;
+}
 .z-0 {
   z-index: 0;
 }
@@ -1084,6 +1087,9 @@ select {
 }
 .mb-2 {
   margin-bottom: 0.5rem;
+}
+.-mt-px {
+  margin-top: -1px;
 }
 .mb-3 {
   margin-bottom: 0.75rem;
@@ -1358,6 +1364,9 @@ select {
 .border-b {
   border-bottom-width: 1px;
 }
+.border-r {
+  border-right-width: 1px;
+}
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
@@ -1376,6 +1385,10 @@ select {
 .border-gray-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 244 246 / var(--tw-border-opacity));
+}
+.border-gray-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 .bg-white {
   --tw-bg-opacity: 1;
@@ -1599,6 +1612,9 @@ select {
 .tracking-widest {
   letter-spacing: 0.1em;
 }
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
 .text-gray-500 {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
@@ -1658,6 +1674,14 @@ select {
 .text-green-500 {
   --tw-text-opacity: 1;
   color: rgb(34 197 94 / var(--tw-text-opacity));
+}
+.text-gray-200 {
+  --tw-text-opacity: 1;
+  color: rgb(229 231 235 / var(--tw-text-opacity));
+}
+.text-gray-300 {
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 .underline {
   -webkit-text-decoration-line: underline;

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -233,7 +233,7 @@ $('#dashboard_send_comment_upload_img').change(function (e) {
     $(this).val('');
     return false;
   } else if (file_size_check('dashboard_send_comment_upload_img')) {
-    dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>ファイルのサイズは1MB以内にしてください</div>";
+    dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>ファイルのサイズは3MB以内にしてください</div>";
     $('#dashboard_send_commnet_img_preview').attr('src', '');
     $(this).val('');
     return false;

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -169,12 +169,6 @@ $('#dashboard_sendMessage_btn').click(function () {
   var bytes_limit = 300;
   var formElm = document.getElementById("dashboard_sendMessage_form");
   var message = formElm.dashboard_message_textarea.value;
-  var $form = $('#dashboard_send_comment_upload_img');
-  var formData = new FormData(); //formData.append('formData', $('#dashboard_send_comment_upload_img').prop('files')[0]);
-
-  formData.append('thread_id', thread_id);
-  formData.append('message', message);
-  formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
 
   if (message.trim() == 0) {
     dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -183,7 +177,6 @@ $('#dashboard_sendMessage_btn').click(function () {
   } else if (message.bytes() > bytes_limit) {
     dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + bytes_limit / 3 + "文字(英数字は " + bytes_limit + "文字)以内にして下さい</div>";
   } else {
-    dashboard_sendAlertArea.innerHTML = "";
     $.ajaxSetup({
       headers: {
         'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
@@ -196,26 +189,33 @@ $('#dashboard_sendMessage_btn').click(function () {
         "table": thread_id,
         "message": message
       }
-    }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+    }).done(function () {
+      if (formElm.dashboard_send_comment_upload_img.value != null) {
+        var formData = new FormData();
+        formData.append('thread_id', thread_id);
+        formData.append('message', message);
+        formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
+        $.ajax({
+          type: "POST",
+          url: url + "/jQuery.ajax/img_upload",
+          data: formData,
+          processData: false,
+          contentType: false
+        }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+          console.log(XMLHttpRequest.status);
+          console.log(textStatus);
+          console.log(errorThrown.message);
+        });
+        $('#dashboard_send_comment_upload_img').val('');
+      }
+    }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
       console.log(XMLHttpRequest.status);
       console.log(textStatus);
       console.log(errorThrown.message);
     });
-    console.log(formData);
-    $.ajax({
-      type: "POST",
-      url: url + "/jQuery.ajax/img_upload",
-      data: formData,
-      processData: false,
-      contentType: false
-    }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-      console.log(XMLHttpRequest.status);
-      console.log(textStatus);
-      console.log(errorThrown.message);
-    });
+    dashboard_sendAlertArea.innerHTML = "";
     formElm.dashboard_message_textarea.value = '';
     $('#dashboard_send_commnet_img_preview').attr('src', '');
-    $('#dashboard_send_comment_upload_img').val('');
   }
 });
 

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -207,6 +207,48 @@ String.prototype.bytes = function () {
 String.prototype.rows = function () {
   if (this.match(/\n/g)) return this.match(/\n/g).length + 1;else return 1;
 };
+
+$('#dashboard_send_comment_upload_img').change(function (e) {
+  var fileset = $(this).val();
+
+  if (fileset !== '' && e.target.files[0].type.indexOf('image') < 0) {
+    dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>画像ファイルを指定してください</div>";
+    $('#dashboard_send_commnet_img_preview').attr('src', '');
+    $(this).val('');
+    return false;
+  } else if (file_size_check('dashboard_send_comment_upload_img')) {
+    dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>ファイルのサイズは1MB以内にしてください</div>";
+    $('#dashboard_send_commnet_img_preview').attr('src', '');
+    $(this).val('');
+    return false;
+  } else {
+    dashboard_sendAlertArea.innerHTML = "";
+
+    if (fileset === '') {
+      $('#dashboard_send_commnet_img_preview').attr('src', '');
+    } else {
+      var reader = new FileReader();
+
+      reader.onload = function (e) {
+        $('#dashboard_send_commnet_img_preview').attr('src', e.target.result);
+      };
+
+      reader.readAsDataURL(e.target.files[0]);
+    }
+  }
+});
+
+function file_size_check(idname) {
+  var fileset = $('#' + idname).prop('files')[0];
+
+  if (fileset) {
+    if (1048576 <= fileset.size) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
 })();
 
 // This entry need to be wrapped in an IIFE because it need to be isolated against other entry modules.

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -48,7 +48,7 @@ $('#dashboard_create_thread_btn').click(function () {
   \**********************************************/
 if (location.href.includes('dashboard/thread/name=')) {
   reload();
-  setInterval(reload, 1000);
+  setInterval(reload, 5000);
 }
 
 function reload() {
@@ -84,10 +84,22 @@ function reload() {
 
       if (data[item]['user_like'] == 0) {
         // いいねが押されていた場合
-        show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>";
+        show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
+
+        if (data[item]['img_path'] != null) {
+          show += "" + "<p>" + "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" + "</p>";
+        }
+
+        show += "" + "<p>" + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>";
       } else {
         // いいねが押されていない場合
-        show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + data[item]['count_user'] + "<hr>";
+        show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
+
+        if (data[item]['img_path'] != null) {
+          show += "" + "<p>" + "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" + "</p>";
+        }
+
+        show += "" + "<p>" + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + data[item]['count_user'] + "<hr>";
       }
 
       displayArea.insertAdjacentHTML('afterbegin', show);

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -87,7 +87,7 @@ function reload() {
         show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
         if (data[item]['img_path'] != null) {
-          show += "" + "<p>" + "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" + "</p>";
+          show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";
         }
 
         show += "" + "<p>" + "</p>" + "<br>" + "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] + "<hr>";
@@ -96,7 +96,7 @@ function reload() {
         show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
         if (data[item]['img_path'] != null) {
-          show += "" + "<p>" + "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" + "</p>";
+          show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', 'storage') + "'>" + "</p>";
         }
 
         show += "" + "<p>" + "</p>" + "<br>" + "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + data[item]['count_user'] + "<hr>";

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -167,9 +167,14 @@ $('#dashboard_threads_category_select').change(search_thread);
 $('#dashboard_sendMessage_btn').click(function () {
   var rows_limit = 20;
   var bytes_limit = 300;
-  var sendAlertArea = document.getElementById("dashboard_sendAlertArea");
   var formElm = document.getElementById("dashboard_sendMessage_form");
   var message = formElm.dashboard_message_textarea.value;
+  var $form = $('#dashboard_send_comment_upload_img');
+  var formData = new FormData(); //formData.append('formData', $('#dashboard_send_comment_upload_img').prop('files')[0]);
+
+  formData.append('thread_id', thread_id);
+  formData.append('message', message);
+  formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
 
   if (message.trim() == 0) {
     dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -196,7 +201,21 @@ $('#dashboard_sendMessage_btn').click(function () {
       console.log(textStatus);
       console.log(errorThrown.message);
     });
+    console.log(formData);
+    $.ajax({
+      type: "POST",
+      url: url + "/jQuery.ajax/img_upload",
+      data: formData,
+      processData: false,
+      contentType: false
+    }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+      console.log(XMLHttpRequest.status);
+      console.log(textStatus);
+      console.log(errorThrown.message);
+    });
     formElm.dashboard_message_textarea.value = '';
+    $('#dashboard_send_commnet_img_preview').attr('src', '');
+    $('#dashboard_send_comment_upload_img').val('');
   }
 });
 

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -169,6 +169,10 @@ $('#dashboard_sendMessage_btn').click(function () {
   var bytes_limit = 300;
   var formElm = document.getElementById("dashboard_sendMessage_form");
   var message = formElm.dashboard_message_textarea.value;
+  var formData = new FormData();
+  formData.append('table', thread_id);
+  formData.append('message', message);
+  formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
 
   if (message.trim() == 0) {
     dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -185,30 +189,10 @@ $('#dashboard_sendMessage_btn').click(function () {
     $.ajax({
       type: "POST",
       url: url + "/jQuery.ajax/sendRow",
-      data: {
-        "table": thread_id,
-        "message": message
-      }
-    }).done(function () {
-      if (formElm.dashboard_send_comment_upload_img.value != null) {
-        var formData = new FormData();
-        formData.append('thread_id', thread_id);
-        formData.append('message', message);
-        formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
-        $.ajax({
-          type: "POST",
-          url: url + "/jQuery.ajax/img_upload",
-          data: formData,
-          processData: false,
-          contentType: false
-        }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-          console.log(XMLHttpRequest.status);
-          console.log(textStatus);
-          console.log(errorThrown.message);
-        });
-        $('#dashboard_send_comment_upload_img').val('');
-      }
-    }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+      data: formData,
+      processData: false,
+      contentType: false
+    }).done(function () {}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
       console.log(XMLHttpRequest.status);
       console.log(textStatus);
       console.log(errorThrown.message);
@@ -216,6 +200,7 @@ $('#dashboard_sendMessage_btn').click(function () {
     dashboard_sendAlertArea.innerHTML = "";
     formElm.dashboard_message_textarea.value = '';
     $('#dashboard_send_commnet_img_preview').attr('src', '');
+    $('#dashboard_send_comment_upload_img').val('');
   }
 });
 

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -258,7 +258,8 @@ function file_size_check(idname) {
   var fileset = $('#' + idname).prop('files')[0];
 
   if (fileset) {
-    if (1048576 <= fileset.size) {
+    // 画像サイズ3MBまで
+    if (3145728 <= fileset.size) {
       return true;
     } else {
       return false;

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -44,7 +44,7 @@ function reload() {
                 if (data[item]['img_path'] != null) {
                     show += "" +
                         "<p>" +
-                        "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" +
+                        "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" +
                         "</p>";
                 }
                 show += "" +
@@ -64,7 +64,7 @@ function reload() {
                 if (data[item]['img_path'] != null) {
                     show += "" +
                         "<p>" +
-                        "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" +
+                        "<img src='" + url + data[item]['img_path'].replace('public', 'storage') + "'>" +
                         "</p>";
                 }
                 show += "" +

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -1,6 +1,6 @@
 if ((location.href).includes('dashboard/thread/name=')) {
     reload();
-    setInterval(reload, 1000);
+    setInterval(reload, 5000);
 }
 
 function reload() {
@@ -40,6 +40,15 @@ function reload() {
                     "<br>" +
                     "<p style='overflow-wrap: break-word;'>" +
                     msg +
+                    "</p>";
+                if (data[item]['img_path'] != null) {
+                    show += "" +
+                        "<p>" +
+                        "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" +
+                        "</p>";
+                }
+                show += "" +
+                    "<p>" +
                     "</p>" +
                     "<br>" +
                     "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'] +
@@ -51,6 +60,15 @@ function reload() {
                     "<br>" +
                     "<p style='overflow-wrap: break-word;'>" +
                     msg +
+                    "</p>";
+                if (data[item]['img_path'] != null) {
+                    show += "" +
+                        "<p>" +
+                        "<img src='" + url + "/storage/" + data[item]['img_path'] + "'>" +
+                        "</p>";
+                }
+                show += "" +
+                    "<p>" +
                     "</p>" +
                     "<br>" +
                     "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + data[item]['count_user'] +

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -3,12 +3,6 @@ $('#dashboard_sendMessage_btn').click(function () {
     var bytes_limit = 300;
     var formElm = document.getElementById("dashboard_sendMessage_form");
     var message = formElm.dashboard_message_textarea.value;
-    let $form = $('#dashboard_send_comment_upload_img');
-    var formData = new FormData();
-    //formData.append('formData', $('#dashboard_send_comment_upload_img').prop('files')[0]);
-    formData.append('thread_id', thread_id);
-    formData.append('message', message);
-    formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
 
     if (message.trim() == 0) {
         dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -17,7 +11,6 @@ $('#dashboard_sendMessage_btn').click(function () {
     } else if (message.bytes() > bytes_limit) {
         dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + bytes_limit / 3 + "文字(英数字は " + bytes_limit + "文字)以内にして下さい</div>";
     } else {
-        dashboard_sendAlertArea.innerHTML = "";
         $.ajaxSetup({
             headers: {
                 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
@@ -31,29 +24,35 @@ $('#dashboard_sendMessage_btn').click(function () {
                 "message": message,
             },
         }).done(function () {
+            if (formElm.dashboard_send_comment_upload_img.value != null) {
+                var formData = new FormData();
+                formData.append('thread_id', thread_id);
+                formData.append('message', message);
+                formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
+
+                $.ajax({
+                    type: "POST",
+                    url: url + "/jQuery.ajax/img_upload",
+                    data: formData,
+                    processData: false,
+                    contentType: false,
+                }).done(function () {
+                }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+                    console.log(XMLHttpRequest.status);
+                    console.log(textStatus);
+                    console.log(errorThrown.message);
+                });
+                $('#dashboard_send_comment_upload_img').val('');
+            }
         }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
             console.log(XMLHttpRequest.status);
             console.log(textStatus);
             console.log(errorThrown.message);
         });
 
-        console.log(formData);
-        $.ajax({
-            type: "POST",
-            url: url + "/jQuery.ajax/img_upload",
-            data: formData,
-            processData: false,
-            contentType: false,
-        }).done(function () {
-        }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-            console.log(XMLHttpRequest.status);
-            console.log(textStatus);
-            console.log(errorThrown.message);
-        });
-
+        dashboard_sendAlertArea.innerHTML = "";
         formElm.dashboard_message_textarea.value = '';
         $('#dashboard_send_commnet_img_preview').attr('src', '');
-        $('#dashboard_send_comment_upload_img').val('');
     }
 });
 

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -58,7 +58,7 @@ $('#dashboard_send_comment_upload_img').change(function (e) {
         $(this).val('');
         return false;
     } else if (file_size_check('dashboard_send_comment_upload_img')) {
-        dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>ファイルのサイズは1MB以内にしてください</div>";
+        dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>ファイルのサイズは3MB以内にしてください</div>";
         $('#dashboard_send_commnet_img_preview').attr('src', '');
         $(this).val('');
         return false;

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -3,6 +3,11 @@ $('#dashboard_sendMessage_btn').click(function () {
     var bytes_limit = 300;
     var formElm = document.getElementById("dashboard_sendMessage_form");
     var message = formElm.dashboard_message_textarea.value;
+    var formData = new FormData();
+    formData.append('table', thread_id);
+    formData.append('message', message);
+    formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
+
 
     if (message.trim() == 0) {
         dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -19,31 +24,10 @@ $('#dashboard_sendMessage_btn').click(function () {
         $.ajax({
             type: "POST",
             url: url + "/jQuery.ajax/sendRow",
-            data: {
-                "table": thread_id,
-                "message": message,
-            },
+            data: formData,
+            processData: false,
+            contentType: false,
         }).done(function () {
-            if (formElm.dashboard_send_comment_upload_img.value != null) {
-                var formData = new FormData();
-                formData.append('thread_id', thread_id);
-                formData.append('message', message);
-                formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
-
-                $.ajax({
-                    type: "POST",
-                    url: url + "/jQuery.ajax/img_upload",
-                    data: formData,
-                    processData: false,
-                    contentType: false,
-                }).done(function () {
-                }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
-                    console.log(XMLHttpRequest.status);
-                    console.log(textStatus);
-                    console.log(errorThrown.message);
-                });
-                $('#dashboard_send_comment_upload_img').val('');
-            }
         }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
             console.log(XMLHttpRequest.status);
             console.log(textStatus);
@@ -53,6 +37,7 @@ $('#dashboard_sendMessage_btn').click(function () {
         dashboard_sendAlertArea.innerHTML = "";
         formElm.dashboard_message_textarea.value = '';
         $('#dashboard_send_commnet_img_preview').attr('src', '');
+        $('#dashboard_send_comment_upload_img').val('');
     }
 });
 

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -79,7 +79,8 @@ $('#dashboard_send_comment_upload_img').change(function (e) {
 function file_size_check(idname) {
     var fileset = $('#' + idname).prop('files')[0];
     if (fileset) {
-        if (1048576 <= fileset.size) {
+        // 画像サイズ3MBまで
+        if (3145728 <= fileset.size) {
             return true;
         } else {
             return false;

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -1,9 +1,14 @@
 $('#dashboard_sendMessage_btn').click(function () {
     var rows_limit = 20;
     var bytes_limit = 300;
-    var sendAlertArea = document.getElementById("dashboard_sendAlertArea");
     var formElm = document.getElementById("dashboard_sendMessage_form");
     var message = formElm.dashboard_message_textarea.value;
+    let $form = $('#dashboard_send_comment_upload_img');
+    var formData = new FormData();
+    //formData.append('formData', $('#dashboard_send_comment_upload_img').prop('files')[0]);
+    formData.append('thread_id', thread_id);
+    formData.append('message', message);
+    formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
 
     if (message.trim() == 0) {
         dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -13,19 +18,17 @@ $('#dashboard_sendMessage_btn').click(function () {
         dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>入力は" + bytes_limit / 3 + "文字(英数字は " + bytes_limit + "文字)以内にして下さい</div>";
     } else {
         dashboard_sendAlertArea.innerHTML = "";
-
         $.ajaxSetup({
             headers: {
                 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
             }
         });
-
         $.ajax({
             type: "POST",
             url: url + "/jQuery.ajax/sendRow",
             data: {
                 "table": thread_id,
-                "message": message
+                "message": message,
             },
         }).done(function () {
         }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
@@ -33,7 +36,24 @@ $('#dashboard_sendMessage_btn').click(function () {
             console.log(textStatus);
             console.log(errorThrown.message);
         });
+
+        console.log(formData);
+        $.ajax({
+            type: "POST",
+            url: url + "/jQuery.ajax/img_upload",
+            data: formData,
+            processData: false,
+            contentType: false,
+        }).done(function () {
+        }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+            console.log(XMLHttpRequest.status);
+            console.log(textStatus);
+            console.log(errorThrown.message);
+        });
+
         formElm.dashboard_message_textarea.value = '';
+        $('#dashboard_send_commnet_img_preview').attr('src', '');
+        $('#dashboard_send_comment_upload_img').val('');
     }
 });
 

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -44,3 +44,41 @@ String.prototype.bytes = function () {
 String.prototype.rows = function () {
     if (this.match(/\n/g)) return (this.match(/\n/g).length) + 1; else return (1);
 }
+
+$('#dashboard_send_comment_upload_img').change(function (e) {
+    var fileset = $(this).val();
+
+    if (fileset !== '' && e.target.files[0].type.indexOf('image') < 0) {
+        dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>画像ファイルを指定してください</div>";
+        $('#dashboard_send_commnet_img_preview').attr('src', '');
+        $(this).val('');
+        return false;
+    } else if (file_size_check('dashboard_send_comment_upload_img')) {
+        dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>ファイルのサイズは1MB以内にしてください</div>";
+        $('#dashboard_send_commnet_img_preview').attr('src', '');
+        $(this).val('');
+        return false;
+    } else {
+        dashboard_sendAlertArea.innerHTML = "";
+        if (fileset === '') {
+            $('#dashboard_send_commnet_img_preview').attr('src', '');
+        } else {
+            var reader = new FileReader();
+            reader.onload = function (e) {
+                $('#dashboard_send_commnet_img_preview').attr('src', e.target.result);
+            }
+            reader.readAsDataURL(e.target.files[0]);
+        }
+    }
+});
+
+function file_size_check(idname) {
+    var fileset = $('#' + idname).prop('files')[0];
+    if (fileset) {
+        if (1048576 <= fileset.size) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -4,11 +4,13 @@
 
 <div class="col-sm-4 col-xs-12">
     <a href="/dashboard">トップページへ</a>
-    <form id="dashboard_sendMessage_form">
+    <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
         <div class="mb-2">
             <label class="form-label">コメント</label>
             <textarea class="form-control" id="dashboard_message_textarea" rows="4"></textarea>
             <br />
+            <input type="file" id="dashboard_send_comment_upload_img">
+            <img src="" id="dashboard_send_commnet_img_preview" class="img_preview">
             <div class="form-text">
                 入力欄の右下にマウスカーソルを移動させると，高さを変えることができます
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,7 +57,6 @@ Route::middleware([
 ])->group(function () {
     Route::match(['get', 'post'], 'jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
     Route::match(['get', 'post'], 'jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
-    Route::match(['get', 'post'], 'jQuery.ajax/img_upload', 'App\Http\Controllers\jQuery_ajax@img_upload');
     Route::match(['get', 'post'], 'jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
     Route::match(['get', 'post'], 'jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
     Route::match(['get', 'post'], 'jQuery.ajax/unlike', "App\Http\Controllers\jQuery_ajax@unlike");

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,7 @@ Route::middleware([
 ])->group(function () {
     Route::match(['get', 'post'], 'jQuery.ajax/getRow', "App\Http\Controllers\jQuery_ajax@get_allRow");
     Route::match(['get', 'post'], 'jQuery.ajax/sendRow', "App\Http\Controllers\jQuery_ajax@send_Row");
+    Route::match(['get', 'post'], 'jQuery.ajax/img_upload', 'App\Http\Controllers\jQuery_ajax@img_upload');
     Route::match(['get', 'post'], 'jQuery.ajax/create_thread', "App\Http\Controllers\jQuery_ajax@create_thread");
     Route::match(['get', 'post'], 'jQuery.ajax/like', "App\Http\Controllers\jQuery_ajax@like");
     Route::match(['get', 'post'], 'jQuery.ajax/unlike', "App\Http\Controllers\jQuery_ajax@unlike");


### PR DESCRIPTION
## 関連

- #128 
- #141 

## なぜこの変更をするのか

- 無し

## やったこと

- データベースに保存する日時のフォーマット変更
- 画像パス保存用のテーブル作成
- 画像アップロード機能追加（画像以外は禁止）
- アップロードされた画像を表示
- 通信データ多くなるので更新を5秒毎に変更
- 画像フォーマットを jpg に変更
- exif情報の削除

## やらないこと

- webp への変換

## できるようになること（ユーザ目線）

- 画像のアップロード

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 複数スレッドで画像のアップロード・表示が出来る事を確認
- 同一スレッドの異なるメッセージで異なる画像をアップロード・表示が出来る事を確認

## その他

無し