### PR TITLE
スレッド名に特殊文字を使用していてもアクセス可能に修正

### DIFF
--- a/resources/views/dashboard/threads.blade.php
+++ b/resources/views/dashboard/threads.blade.php
@@ -88,7 +88,7 @@
             @if ($flag == 1)
             <tr>
                 <td>
-                    <a href="/dashboard/thread/name={{ $tableInfo['thread_name'] }}&id={{ $tableInfo['thread_id'] }}"
+                    <a href="/dashboard/thread/name={{ $tableName }}&id={{ $tableInfo['thread_id'] }}"
                         class="text-decoration-none">
                         {{$tableInfo["thread_name"]}}
                     </a>


### PR DESCRIPTION
## 関連

- #144 

## なぜこの変更をするのか
- 無し

## やったこと

- スレッドにアクセスするURL部分を特殊文字変換

## やらないこと

無し

## できるようになること（ユーザ目線）

- `/`, `\`, `#` をスレッド名に使用出来る様になる

## できなくなること（ユーザ目線）

無し

## 動作確認

- `/`, `\`, `#` を含んだスレッド名にアクセス出来る事を確認

## その他

無し