### PR TITLE
書き込みに返信を行いやすいように

### DIFF
--- a/app/Http/Controllers/jQuery_ajax.php
+++ b/app/Http/Controllers/jQuery_ajax.php
@@ -189,6 +189,11 @@ class jQuery_ajax extends Controller
             $message = str_replace($key, $value, $message);
         }
 
+        if ($request->reply != null) {
+            $reply = '<a class="bg-info" href="#thread_message_id_' . str_replace('>>> ', '', $request->reply) . '">' . $request->reply . '</a>';
+            $message = $reply . '<br>' . $message;
+        }
+
         $thread = Hub::where('thread_id', '=', $request->table)->first();
         $message_id = 0;
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1097,6 +1097,9 @@ select {
 .block {
   display: block;
 }
+.inline {
+  display: inline;
+}
 .flex {
   display: flex;
 }
@@ -1276,6 +1279,9 @@ select {
 }
 .justify-between {
   justify-content: space-between;
+}
+.justify-items-center {
+  justify-items: center;
 }
 .gap-6 {
   gap: 1.5rem;

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -82,7 +82,7 @@ function reload() {
         msg = "<br>この投稿は管理者によって削除されました";
       }
 
-      show = "" + data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
+      show = "" + "<p>" + "<a href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "</p>" + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
       if (data[item]['img_path'] != null) {
         show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -82,7 +82,7 @@ function reload() {
         msg = "<br>この投稿は管理者によって削除されました";
       }
 
-      show = "" + "<p>" + "<a href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "</p>" + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
+      show = "" + "<p>" + "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "</p>" + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
       if (data[item]['img_path'] != null) {
         show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -112,6 +112,17 @@ function reload() {
 // This entry need to be wrapped in an IIFE because it need to be isolated against other entry modules.
 (() => {
 /*!*************************************************!*\
+  !*** ./resources/js/dashboard/Reply_message.js ***!
+  \*************************************************/
+$("#dashboard_send_comment_replay_clear").click(function () {
+  $('#dashboard_send_comment_reply_disabled_text').val('');
+  $('#dashboard_send_comment_reply_source').attr('href', '#!');
+});
+})();
+
+// This entry need to be wrapped in an IIFE because it need to be isolated against other entry modules.
+(() => {
+/*!*************************************************!*\
   !*** ./resources/js/dashboard/Search_thread.js ***!
   \*************************************************/
 $('#dashboard_threads_search_thread').keyup(search_thread);

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -82,13 +82,13 @@ function reload() {
         msg = "<br>この投稿は管理者によって削除されました";
       }
 
-      show = "" + "<p>" + "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "</p>" + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
+      show = "" + "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
       if (data[item]['img_path'] != null) {
         show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";
       }
 
-      show += "" + "<p>" + "</p>" + "<br>";
+      show += "<br>";
 
       if (data[item]['user_like'] == 0) {
         // いいねが押されていない場合
@@ -189,9 +189,11 @@ $('#dashboard_sendMessage_btn').click(function () {
   var bytes_limit = 300;
   var formElm = document.getElementById("dashboard_sendMessage_form");
   var message = formElm.dashboard_message_textarea.value;
+  var reply = formElm.dashboard_send_comment_reply_disabled_text.value;
   var formData = new FormData();
   formData.append('table', thread_id);
   formData.append('message', message);
+  formData.append('reply', reply);
   formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
 
   if (message.trim() == 0) {
@@ -221,6 +223,8 @@ $('#dashboard_sendMessage_btn').click(function () {
     formElm.dashboard_message_textarea.value = '';
     $('#dashboard_send_commnet_img_preview').attr('src', '');
     $('#dashboard_send_comment_upload_img').val('');
+    $('#dashboard_send_comment_reply_disabled_text').val('');
+    $('#dashboard_send_comment_reply_source').attr('href', '#!');
   }
 });
 

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -34,9 +34,7 @@ function reload() {
             }
 
             show = "" +
-                "<p>" +
                 "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] +
-                "</p>" +
                 "<br>" +
                 "<p style='overflow-wrap: break-word;'>" +
                 msg +
@@ -47,10 +45,7 @@ function reload() {
                     "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" +
                     "</p>";
             }
-            show += "" +
-                "<p>" +
-                "</p>" +
-                "<br>";
+            show += "<br>";
 
             if (data[item]['user_like'] == 0) {
                 // いいねが押されていない場合

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -33,9 +33,10 @@ function reload() {
                 msg = "<br>この投稿は管理者によって削除されました";
             }
 
-
             show = "" +
-                data[item]['message_id'] + ": " + user + " " + data[item]['created_at'] +
+                "<p>" +
+                "<a href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] +
+                "</p>" +
                 "<br>" +
                 "<p style='overflow-wrap: break-word;'>" +
                 msg +
@@ -69,5 +70,3 @@ function reload() {
         console.log(errorThrown.message);
     });
 }
-
-

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -35,7 +35,7 @@ function reload() {
 
             show = "" +
                 "<p>" +
-                "<a href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] +
+                "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] +
                 "</p>" +
                 "<br>" +
                 "<p style='overflow-wrap: break-word;'>" +

--- a/resources/js/dashboard/Reply_message.js
+++ b/resources/js/dashboard/Reply_message.js
@@ -1,0 +1,4 @@
+$("#dashboard_send_comment_replay_clear").click(function () {
+    $('#dashboard_send_comment_reply_disabled_text').val('');
+    $('#dashboard_send_comment_reply_source').attr('href', '#!');
+});

--- a/resources/js/dashboard/Send_Row.js
+++ b/resources/js/dashboard/Send_Row.js
@@ -3,11 +3,12 @@ $('#dashboard_sendMessage_btn').click(function () {
     var bytes_limit = 300;
     var formElm = document.getElementById("dashboard_sendMessage_form");
     var message = formElm.dashboard_message_textarea.value;
+    var reply = formElm.dashboard_send_comment_reply_disabled_text.value;
     var formData = new FormData();
     formData.append('table', thread_id);
     formData.append('message', message);
+    formData.append('reply', reply);
     formData.append('img', $('#dashboard_send_comment_upload_img').prop('files')[0]);
-
 
     if (message.trim() == 0) {
         dashboard_sendAlertArea.innerHTML = "<div class='alert alert-danger'>書き込みなし・空白・改行のみの投稿は出来ません</div>";
@@ -38,6 +39,8 @@ $('#dashboard_sendMessage_btn').click(function () {
         formElm.dashboard_message_textarea.value = '';
         $('#dashboard_send_commnet_img_preview').attr('src', '');
         $('#dashboard_send_comment_upload_img').val('');
+        $('#dashboard_send_comment_reply_disabled_text').val('');
+        $('#dashboard_send_comment_reply_source').attr('href', '#!');
     }
 });
 

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -2,10 +2,13 @@
     スレッドへ書き込むための部分
  -->
 
-<div class="col-sm-4 col-xs-12">
-    <a href="/dashboard">トップページへ</a>
+ <div class="col-sm-4 col-xs-12">
+    <a class="h4" href="/dashboard">トップページへ</a>
     <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
         <div class="mb-2">
+            <a id="dashboard_send_comment_reply_source" href="#!">
+                <input class="form-control" type="text" id="dashboard_send_comment_reply_disabled_text" disabled>
+            </a>
             <label id="dashboard_send_comment_label" class="form-label">コメント</label>
             <textarea class="form-control" id="dashboard_message_textarea" rows="4"></textarea>
             <br />
@@ -25,6 +28,12 @@
 <!-- ここからデザイン関係なし -->
 <script>
     const url = "{{ url('') }}";
+</script>
+<script>
+    function reply(message_id) {
+        $('#dashboard_send_comment_reply_disabled_text').val(">>> " + message_id);
+        $('#dashboard_send_comment_reply_source').attr('href', '#thread_message_id_' + message_id);
+    }
 </script>
 <script src="{{ mix('js/app_jquery.js') }}"></script>
 <!-- ここまでデザイン関係なし -->

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -6,7 +6,7 @@
     <a href="/dashboard">トップページへ</a>
     <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
         <div class="mb-2">
-            <label class="form-label">コメント</label>
+            <label id="dashboard_send_comment_label" class="form-label">コメント</label>
             <textarea class="form-control" id="dashboard_message_textarea" rows="4"></textarea>
             <br />
             <input type="file" id="dashboard_send_comment_upload_img">

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -2,13 +2,21 @@
     スレッドへ書き込むための部分
  -->
 
- <div class="col-sm-4 col-xs-12">
+<div class="col-sm-4 col-xs-12">
     <a class="h4" href="/dashboard">トップページへ</a>
     <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
         <div class="mb-2">
-            <a id="dashboard_send_comment_reply_source" href="#!">
-                <input class="form-control" type="text" id="dashboard_send_comment_reply_disabled_text" disabled>
-            </a>
+            <div class="row">
+                <div class="col-8">
+                    <a id="dashboard_send_comment_reply_source" href="#!">
+                        <input class="form-control" type="text" id="dashboard_send_comment_reply_disabled_text"
+                            disabled>
+                    </a>
+                </div>
+                <div class="col-4">
+                    <a id="dashboard_send_comment_replay_clear" href="#!">クリア</a>
+                </div>
+            </div>
             <label id="dashboard_send_comment_label" class="form-label">コメント</label>
             <textarea class="form-control" id="dashboard_message_textarea" rows="4"></textarea>
             <br />


### PR DESCRIPTION
## 関連

- #104 

## なぜこの変更をするのか

無し

## やったこと

- 書き込みの際に返信元のメッセージに移動しやすいように補助
- 閲覧の際に返信元のメッセージに移動しやすいように補助

## やらないこと

無し

## できるようになること（ユーザ目線）

- 書き込みに対する返信がしやすくなる
- 閲覧時に返信元が確認しやすくなる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 書き込みの際の返信元をわかりやすくする補助が動作していることを確認
- 閲覧の際に返信元をわかりやすくする補助が動作していることを確認

## その他

- 無し