### PR TITLE
スレッドのソートができるように修正・未使用の箇所を削除

### DIFF
--- a/app/Http/Livewire/Dashboard/Threads.php
+++ b/app/Http/Livewire/Dashboard/Threads.php
@@ -82,31 +82,9 @@ class Threads extends Component
     public function render(Request $request)
     {
         $response['tables'] = $this->threads;
-        $response['category'] = $request->category;
+        $response['category_name'] = $request->category;
         $response['page'] = $request->page;
 
         return view('dashboard.threads', $response);
-    }
-
-    public function new_create()
-    {
-        $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
-            ->leftJoin('access_logs', function ($join) {
-                $join->on('hub.thread_id', '=', 'access_logs.thread_id');
-            })
-            ->groupBy('hub.thread_id')
-            ->orderByRaw('hub.created_at DESC')
-            ->get();
-    }
-
-    public function access_count()
-    {
-        $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
-            ->leftJoin('access_logs', function ($join) {
-                $join->on('hub.thread_id', '=', 'access_logs.thread_id');
-            })
-            ->groupBy('hub.thread_id')
-            ->orderByRaw('COUNT(access_logs.access_log) DESC')
-            ->get();
     }
 }

--- a/resources/views/dashboard/threads.blade.php
+++ b/resources/views/dashboard/threads.blade.php
@@ -54,13 +54,13 @@
                 <!-- ここからソートのためのリンク -->
                 <th>
                     <button
-                        onclick="location.href='/dashboard?category={{ $category }}&page={{ $page }}&sort=new_create'">
+                        onclick="location.href='dashboard?category={{ $category_name }}&page={{ $page }}&sort=new_create'">
                         {{ __("Create time") }}
                     </button>
                 </th>
                 <th>
                     <button
-                        onclick="location.href='/dashboard?category={{ $category }}&page={{ $page }}&sort=access_count'">
+                        onclick="location.href='dashboard?category={{ $category_name }}&page={{ $page }}&sort=access_count'">
                         {{ __('Access number') }}
                     </button>
                 </th>


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- スレッド一覧表示部分のソートができなくなっていたから

## やったこと

- ソートに使用するURLのPHPの変数名が重複していたため修正
- 使用していない処理の部分を削除

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- スレッドのソートができるようになる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 新作順・アクセス順にソートができることを確認

## その他

無し