### PR TITLE
現状のdocker環境構築では必要だったのでurlからpublicを消す手段追加

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,19 @@
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews
+    </IfModule>
+
+    RewriteEngine On
+
+    RewriteCond %{REQUEST_FILENAME} -d [OR]
+    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^ ^$1 [N]
+
+    RewriteCond %{REQUEST_URI} (\.\w+$) [NC]
+    RewriteRule ^(.*)$ public/$1
+
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ server.php
+
+</IfModule>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -965,20 +965,6 @@ select {
 .prose > :where(:last-child):not(:where([class~="not-prose"] *)) {
   margin-bottom: 0;
 }
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-.visible {
-  visibility: visible;
-}
 .fixed {
   position: fixed;
 }
@@ -999,9 +985,6 @@ select {
 }
 .right-0 {
   right: 0px;
-}
-.top-0 {
-  top: 0px;
 }
 .z-0 {
   z-index: 0;
@@ -1087,9 +1070,6 @@ select {
 }
 .mb-2 {
   margin-bottom: 0.5rem;
-}
-.-mt-px {
-  margin-top: -1px;
 }
 .mb-3 {
   margin-bottom: 0.75rem;
@@ -1367,9 +1347,6 @@ select {
 .border-b {
   border-bottom-width: 1px;
 }
-.border-r {
-  border-right-width: 1px;
-}
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
@@ -1388,10 +1365,6 @@ select {
 .border-gray-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 244 246 / var(--tw-border-opacity));
-}
-.border-gray-400 {
-  --tw-border-opacity: 1;
-  border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 .bg-white {
   --tw-bg-opacity: 1;
@@ -1615,9 +1588,6 @@ select {
 .tracking-widest {
   letter-spacing: 0.1em;
 }
-.tracking-wider {
-  letter-spacing: 0.05em;
-}
 .text-gray-500 {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
@@ -1677,14 +1647,6 @@ select {
 .text-green-500 {
   --tw-text-opacity: 1;
   color: rgb(34 197 94 / var(--tw-text-opacity));
-}
-.text-gray-200 {
-  --tw-text-opacity: 1;
-  color: rgb(229 231 235 / var(--tw-text-opacity));
-}
-.text-gray-300 {
-  --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 .underline {
   -webkit-text-decoration-line: underline;

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -46,7 +46,7 @@ $('#dashboard_create_thread_btn').click(function () {
 /*!**********************************************!*\
   !*** ./resources/js/dashboard/Get_allRow.js ***!
   \**********************************************/
-if (location.href.includes('public/dashboard/thread/name=')) {
+if (location.href.includes('dashboard/thread/name=') || location.href.includes('public/dashboard/thread/name=')) {
   reload();
   setInterval(reload, 5000);
 }

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -1,4 +1,4 @@
-if ((location.href).includes('public/dashboard/thread/name=')) {
+if ((location.href).includes('dashboard/thread/name=') || (location.href).includes('public/dashboard/thread/name=')) {
     reload();
     setInterval(reload, 5000);
 }


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- dockerの開発環境はurlからpublicを消す事を前提とされていたから

## やったこと

- urlにpublicなしでも動くように `.htaccess` を追加
- publicがあっても書き込みを取得出来る様に変更

## やらないこと

無し

## できるようになること（ユーザ目線）

- urlにpublicを含めていてもアクセス出来る様になる

## できなくなること（ユーザ目線）

無し

## 動作確認

- 実際にdockerでの環境で書き込みを取得出来る事を確認

## その他

無し