### PR TITLE
ラベルの自動追加

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,14 @@
+name: Label Issues
+on:
+  issues:
+    types:
+      - closed
+jobs:
+  label-pull_request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Closed
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "Close: Normal"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -1,0 +1,25 @@
+name: Label Pull request
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    types:
+      - closed
+jobs:
+  label-pull_request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merged
+        id: merged
+        if: github.event.pull_request.merged == true
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "Close: Normal"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Closed
+        if: "!(steps.merged.conclusion == 'success')"
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "Close: invalid"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -1,9 +1,6 @@
 name: Label Pull request
 on:
   pull_request:
-    branches:
-      - develop
-      - main
     types:
       - closed
 jobs:

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -4,9 +4,6 @@ on:
     types:
       - closed
 
-permissions:
-  pull-requests: write
-
 jobs:
   label-pull_request:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -1,6 +1,9 @@
-name: Label Pull request
+name: Label pull_request
 on:
   pull_request:
+    types:
+      - closed
+  issues:
     types:
       - closed
 jobs:

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -4,7 +4,20 @@ on:
     types:
       - closed
 
-permissions: write-all
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  deployments: write
+  id-token: write
+  issues: write
+  discussions: write
+  packages: write
+  pages: write
+  pull-requests: write
+  repository-projects: write
+  security-events: write
+  statuses: write
 
 jobs:
   label-pull_request:

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -1,11 +1,12 @@
-name: Label pull_request
+name: Label Pull request
 on:
   pull_request:
     types:
       - closed
-  issues:
-    types:
-      - closed
+
+permissions:
+  pull-requests: write
+
 jobs:
   label-pull_request:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-pull_request.yml
+++ b/.github/workflows/label-pull_request.yml
@@ -4,6 +4,8 @@ on:
     types:
       - closed
 
+permissions: write-all
+
 jobs:
   label-pull_request:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 関連

無し

## なぜこの変更をするのか

- `pull request` の `close` 時にラベルを貼り付け忘れる事が多いから
- `issues` の `close` 時はほとんど忘れないけどついでに

## やったこと

- `pull request` の `merge` ・ `close` 時にラベルを自動貼り付け
- `issues` の `close` 時にラベルを自動貼り付け

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- 無し

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- 無し

## その他

このプルリクエストを `merge` ・ `close` した時の動きで動作確認します
issues の方は fork 先の自分のリポジトリで確認します