### PR TITLE
メッセージの取得改良

### DIFF
--- a/app/Http/Controllers/dashboard/ClubThreadsController.php
+++ b/app/Http/Controllers/dashboard/ClubThreadsController.php
@@ -65,10 +65,11 @@ class ClubThreadsController extends Controller
      *
      * @param string $user_email
      * @param string $thread_id
+     * @param int $pre_max_message_id
      *
      * @return Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
         $this->user_email = $user_email;
         $this->thread_id = $thread_id;
@@ -96,6 +97,7 @@ class ClubThreadsController extends Controller
                     ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
             })
             ->where('club_threads.thread_id', '=', $this->thread_id)
+            ->where('club_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('club_threads.message_id')
             ->get();
     }

--- a/app/Http/Controllers/dashboard/CollegeYearThreadsController.php
+++ b/app/Http/Controllers/dashboard/CollegeYearThreadsController.php
@@ -65,10 +65,11 @@ class CollegeYearThreadsController extends Controller
      *
      * @param string $user_email
      * @param string $thread_id
+     * @param int $pre_max_message_id
      *
      * @return Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
         $this->user_email = $user_email;
         $this->thread_id = $thread_id;
@@ -96,6 +97,7 @@ class CollegeYearThreadsController extends Controller
                     ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
             })
             ->where('college_year_threads.thread_id', '=', $this->thread_id)
+            ->where('college_year_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('college_year_threads.message_id')
             ->get();
     }

--- a/app/Http/Controllers/dashboard/DepartmentThreadsController.php
+++ b/app/Http/Controllers/dashboard/DepartmentThreadsController.php
@@ -65,10 +65,11 @@ class DepartmentThreadsController extends Controller
      *
      * @param string $user_email
      * @param string $thread_id
+     * @param int $pre_max_message_id
      *
      * @return Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
         $this->user_email = $user_email;
         $this->thread_id = $thread_id;
@@ -96,6 +97,7 @@ class DepartmentThreadsController extends Controller
                     ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
             })
             ->where('department_threads.thread_id', '=', $this->thread_id)
+            ->where('department_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('department_threads.message_id')
             ->get();
     }

--- a/app/Http/Controllers/dashboard/JobHuntingThreadsController.php
+++ b/app/Http/Controllers/dashboard/JobHuntingThreadsController.php
@@ -65,10 +65,11 @@ class JobHuntingThreadsController extends Controller
      *
      * @param string $user_email
      * @param string $thread_id
+     * @param int $pre_max_message_id
      *
      * @return Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
         $this->user_email = $user_email;
         $this->thread_id = $thread_id;
@@ -96,6 +97,7 @@ class JobHuntingThreadsController extends Controller
                     ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
             })
             ->where('job_hunting_threads.thread_id', '=', $this->thread_id)
+            ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('job_hunting_threads.message_id')
             ->get();
     }

--- a/app/Http/Controllers/dashboard/LectureThreadsController.php
+++ b/app/Http/Controllers/dashboard/LectureThreadsController.php
@@ -65,10 +65,11 @@ class LectureThreadsController extends Controller
      *
      * @param string $user_email
      * @param string $thread_id
+     * @param int $pre_max_message_id
      *
      * @return Illuminate\Support\Collection
      */
-    public function show(string $user_email, string $thread_id)
+    public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {
         $this->user_email = $user_email;
         $this->thread_id = $thread_id;
@@ -96,6 +97,7 @@ class LectureThreadsController extends Controller
                     ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
             })
             ->where('lecture_threads.thread_id', '=', $this->thread_id)
+            ->where('lecture_threads.message_id', '>', $pre_max_message_id)
             ->groupBy('lecture_threads.message_id')
             ->get();
     }

--- a/app/Http/Controllers/dashboard/LikesController.php
+++ b/app/Http/Controllers/dashboard/LikesController.php
@@ -32,7 +32,7 @@ class LikesController extends Controller
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return void
+     * @return Illuminate\Support\Collection
      */
     public function store(Request $request)
     {
@@ -42,6 +42,10 @@ class LikesController extends Controller
             'user_email' => $request->user()->email,
             'created_at' => now(),
         ]);
+
+        return Likes::where('thread_id', '=', $request->thread_id)
+            ->where('message_id', '=', $request->message_id)
+            ->count();
     }
 
     /**
@@ -82,7 +86,7 @@ class LikesController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  \Illuminate\Htt\Request $request
-     * @return void
+     * @return Illuminate\Support\Collection
      */
     public function destroy(Request $request)
     {
@@ -90,5 +94,9 @@ class LikesController extends Controller
             ->where('message_id', '=', $request->message_id)
             ->where('user_email', '=', $request->user()->email)
             ->delete();
+
+        return Likes::where('thread_id', '=', $request->thread_id)
+            ->where('message_id', '=', $request->message_id)
+            ->count();
     }
 }

--- a/app/Http/Controllers/dashboard/LikesController.php
+++ b/app/Http/Controllers/dashboard/LikesController.php
@@ -32,7 +32,7 @@ class LikesController extends Controller
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return Illuminate\Support\Collection
+     * @return int
      */
     public function store(Request $request)
     {
@@ -86,7 +86,7 @@ class LikesController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  \Illuminate\Htt\Request $request
-     * @return Illuminate\Support\Collection
+     * @return int
      */
     public function destroy(Request $request)
     {

--- a/app/Http/Controllers/dashboard/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/ThreadsController.php
@@ -93,15 +93,15 @@ class ThreadsController extends Controller
         $thread = Hub::where('thread_id', '=', $request->table)->first();
         switch ($thread->thread_category_type) {
             case '学科':
-                return (new DepartmentThreadsController)->show($request->user()->email, $request->table);
+                return (new DepartmentThreadsController)->show($request->user()->email, $request->table, $request->max_message_id);
             case '学年':
-                return (new CollegeYearThreadsController)->show($request->user()->email, $request->table);
+                return (new CollegeYearThreadsController)->show($request->user()->email, $request->table, $request->max_message_id);
             case '部活':
-                return (new ClubThreadsController)->show($request->user()->email, $request->table);
+                return (new ClubThreadsController)->show($request->user()->email, $request->table, $request->max_message_id);
             case '授業':
-                return (new LectureThreadsController)->show($request->user()->email, $request->table);
+                return (new LectureThreadsController)->show($request->user()->email, $request->table, $request->max_message_id);
             case '就職':
-                return (new JobHuntingThreadsController)->show($request->user()->email, $request->table);
+                return (new JobHuntingThreadsController)->show($request->user()->email, $request->table, $request->max_message_id);
             default:
                 return null;
         }

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -56,7 +56,7 @@ function create_thread() {
 if (show_thread_messages_flag === 1) {
   show_thread_messages_flag = 0;
   reload();
-  setInterval(reload, 5000);
+  setInterval(reload, 1000);
 }
 
 function reload() {
@@ -74,11 +74,10 @@ function reload() {
     url: url + "/jQuery.ajax/getRow",
     dataType: "json",
     data: {
-      "table": thread_id
+      "table": thread_id,
+      "max_message_id": max_message_id
     }
   }).done(function (data) {
-    displayArea.innerHTML = "<br>";
-
     for (var item in data) {
       if (data[item]['is_validity']) {
         // 通常
@@ -108,6 +107,7 @@ function reload() {
 
       show += "<hr>";
       displayArea.insertAdjacentHTML('afterbegin', show);
+      max_message_id = data[item]['message_id'];
     }
   }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
     console.log(XMLHttpRequest.status);

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -95,17 +95,17 @@ function reload() {
         show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";
       }
 
-      show += "<br>";
+      show += "" + "<br>" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' ";
 
       if (data[item]['user_like'] == 0) {
         // いいねが押されていない場合
-        show += "" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' " + "class='btn btn-light' " + "onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
+        show += "class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>";
       } else {
         // いいねが押されていた場合
-        show += "" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' " + "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
+        show += "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>";
       }
 
-      show += "<hr>";
+      show += "" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>" + "<hr>";
       displayArea.insertAdjacentHTML('afterbegin', show);
       max_message_id = data[item]['message_id'];
     }

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -89,7 +89,7 @@ function reload() {
         msg = "<br>この投稿は管理者によって削除されました";
       }
 
-      show = "" + "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
+      show = "" + "<a " + "id='thread_message_id_" + data[item]['message_id'] + "' " + "href='#dashboard_send_comment_label' " + "type='button' " + "onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] + "<br>" + "<p style='overflow-wrap: break-word;'>" + msg + "</p>";
 
       if (data[item]['img_path'] != null) {
         show += "" + "<p>" + "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" + "</p>";
@@ -99,10 +99,10 @@ function reload() {
 
       if (data[item]['user_like'] == 0) {
         // いいねが押されていない場合
-        show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
+        show += "" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' " + "class='btn btn-light' " + "onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
       } else {
         // いいねが押されていた場合
-        show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
+        show += "" + "<button " + "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " + "type='button' " + "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>" + "like" + "</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
       }
 
       show += "<hr>";

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -99,10 +99,10 @@ function reload() {
 
       if (data[item]['user_like'] == 0) {
         // いいねが押されていない場合
-        show += "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'];
+        show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
       } else {
         // いいねが押されていた場合
-        show += "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + data[item]['count_user'];
+        show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
       }
 
       show += "<hr>";

--- a/public/js/app_jquery.js
+++ b/public/js/app_jquery.js
@@ -53,7 +53,8 @@ function create_thread() {
 /*!**********************************************!*\
   !*** ./resources/js/dashboard/Get_allRow.js ***!
   \**********************************************/
-if (location.href.includes('dashboard/thread/name=') || location.href.includes('public/dashboard/thread/name=')) {
+if (show_thread_messages_flag === 1) {
+  show_thread_messages_flag = 0;
   reload();
   setInterval(reload, 5000);
 }

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -52,10 +52,10 @@ function reload() {
 
             if (data[item]['user_like'] == 0) {
                 // いいねが押されていない場合
-                show += "<button type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + data[item]['user_like'] + ")'>like</button> " + data[item]['count_user'];
+                show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
             } else {
                 // いいねが押されていた場合
-                show += "<button type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + data[item]['count_user'];
+                show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
             }
 
             show += "<hr>";

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -37,7 +37,14 @@ function reload() {
             }
 
             show = "" +
-                "<a id='thread_message_id_" + data[item]['message_id'] + "' href='#dashboard_send_comment_label' type='button' onClick='reply(" + data[item]['message_id'] + ")'>" + data[item]['message_id'] + "</a>" + ": " + user + " " + data[item]['created_at'] +
+                "<a " +
+                "id='thread_message_id_" + data[item]['message_id'] + "' " +
+                "href='#dashboard_send_comment_label' " +
+                "type='button' " +
+                "onClick='reply(" + data[item]['message_id'] + ")'>" +
+                data[item]['message_id'] +
+                "</a>" +
+                ": " + user + " " + data[item]['created_at'] +
                 "<br>" +
                 "<p style='overflow-wrap: break-word;'>" +
                 msg +
@@ -52,10 +59,29 @@ function reload() {
 
             if (data[item]['user_like'] == 0) {
                 // いいねが押されていない場合
-                show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
+                show += "" +
+                    "<button " +
+                    "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " +
+                    "type='button' " +
+                    "class='btn btn-light' " +
+                    "onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>" +
+                    "like" +
+                    "</button> " +
+                    "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" +
+                    data[item]['count_user'] +
+                    "</dev>";
             } else {
                 // いいねが押されていた場合
-                show += "<button id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' type='button' class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>like</button> " + "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" + data[item]['count_user'] + "</dev>";
+                show += "" +
+                    "<button " +
+                    "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " +
+                    "type='button' " +
+                    "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>" +
+                    "like" +
+                    "</button> " +
+                    "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" +
+                    data[item]['count_user'] +
+                    "</dev>";
             }
 
             show += "<hr>";

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -1,4 +1,5 @@
-if ((location.href).includes('dashboard/thread/name=') || (location.href).includes('public/dashboard/thread/name=')) {
+if (show_thread_messages_flag === 1) {
+    show_thread_messages_flag = 0;
     reload();
     setInterval(reload, 5000);
 }

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -1,7 +1,7 @@
 if (show_thread_messages_flag === 1) {
     show_thread_messages_flag = 0;
     reload();
-    setInterval(reload, 5000);
+    setInterval(reload, 1000);
 }
 
 function reload() {
@@ -20,9 +20,11 @@ function reload() {
         type: "POST",
         url: url + "/jQuery.ajax/getRow",
         dataType: "json",
-        data: { "table": thread_id }
+        data: {
+            "table": thread_id,
+            "max_message_id": max_message_id
+        }
     }).done(function (data) {
-        displayArea.innerHTML = "<br>";
         for (var item in data) {
             if (data[item]['is_validity']) {
                 // 通常
@@ -59,6 +61,7 @@ function reload() {
             show += "<hr>";
 
             displayArea.insertAdjacentHTML('afterbegin', show);
+            max_message_id = data[item]['message_id'];
         }
     }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
         console.log(XMLHttpRequest.status);

--- a/resources/js/dashboard/Get_allRow.js
+++ b/resources/js/dashboard/Get_allRow.js
@@ -49,42 +49,35 @@ function reload() {
                 "<p style='overflow-wrap: break-word;'>" +
                 msg +
                 "</p>";
+
             if (data[item]['img_path'] != null) {
                 show += "" +
                     "<p>" +
                     "<img src='" + url + data[item]['img_path'].replace('public', '/storage') + "'>" +
                     "</p>";
             }
-            show += "<br>";
+
+            show += "" +
+                "<br>" +
+                "<button " +
+                "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " +
+                "type='button' ";
 
             if (data[item]['user_like'] == 0) {
                 // いいねが押されていない場合
-                show += "" +
-                    "<button " +
-                    "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " +
-                    "type='button' " +
-                    "class='btn btn-light' " +
-                    "onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>" +
-                    "like" +
-                    "</button> " +
-                    "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" +
-                    data[item]['count_user'] +
-                    "</dev>";
+                show += "class='btn btn-light' onClick='likes(" + data[item]['message_id'] + ", " + 0 + ")'>";
             } else {
                 // いいねが押されていた場合
-                show += "" +
-                    "<button " +
-                    "id='js_dashboard_Get_allRow_button_" + data[item]['message_id'] + "' " +
-                    "type='button' " +
-                    "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>" +
-                    "like" +
-                    "</button> " +
-                    "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" +
-                    data[item]['count_user'] +
-                    "</dev>";
+                show += "class='btn btn-dark' onClick='likes(" + data[item]['message_id'] + ", " + 1 + ")'>";
             }
 
-            show += "<hr>";
+            show += "" +
+                "like" +
+                "</button> " +
+                "<dev id='js_dashboard_Get_allRow_dev_" + data[item]['message_id'] + "'>" +
+                data[item]['count_user'] +
+                "</dev>" +
+                "<hr>";
 
             displayArea.insertAdjacentHTML('afterbegin', show);
             max_message_id = data[item]['message_id'];

--- a/resources/views/dashboard/messages.blade.php
+++ b/resources/views/dashboard/messages.blade.php
@@ -2,7 +2,7 @@
 <script>
     const table = "{{ $thread_name }}";
     const thread_id = "{{ $thread_id }}";
-    const max_message_id = 0;
+    var max_message_id = 0;
 </script>
 
 <script>

--- a/resources/views/dashboard/messages.blade.php
+++ b/resources/views/dashboard/messages.blade.php
@@ -6,7 +6,19 @@
 </script>
 
 <script>
-    function likes(message_id, user_like) {
+    function likes(message_id) {
+        var access = "";
+
+        $('#js_dashboard_Get_allRow_button_' + message_id).prop('disabled', true);
+        $('#js_dashboard_Get_allRow_button_' + message_id).toggleClass('btn-light');
+        $('#js_dashboard_Get_allRow_button_' + message_id).toggleClass('btn-dark');
+
+        if ($('#js_dashboard_Get_allRow_button_' + message_id).hasClass('btn-dark')) {
+            access = '/jQuery.ajax/like';
+        } else {
+            access = '/jQuery.ajax/unlike';
+        }
+
         $.ajaxSetup({
             headers: {
                 "X-CSRF-TOKEN": $(
@@ -14,46 +26,20 @@
                 ).attr("content"),
             },
         });
-
-        if (user_like == 1) {
-            $.ajax({
-                type: "POST",
-                url: url + "/jQuery.ajax/unlike",
-                data: {
-                    thread_id: thread_id,
-                    message_id: message_id,
-                },
-            })
-                .done(function () { })
-                .fail(function (
-                    XMLHttpRequest,
-                    textStatus,
-                    errorThrown
-                ) {
-                    console.log(XMLHttpRequest.status);
-                    console.log(textStatus);
-                    console.log(errorThrown.message);
-                });
-        } else {
-            $.ajax({
-                type: "POST",
-                url: url + "/jQuery.ajax/like",
-                data: {
-                    thread_id: thread_id,
-                    message_id: message_id,
-                },
-            })
-                .done(function () { })
-                .fail(function (
-                    XMLHttpRequest,
-                    textStatus,
-                    errorThrown
-                ) {
-                    console.log(XMLHttpRequest.status);
-                    console.log(textStatus);
-                    console.log(errorThrown.message);
-                });
-        }
+        $.ajax({
+            type: "POST",
+            url: url + access,
+            data: {
+                thread_id: thread_id,
+                message_id: message_id,
+            },
+        }).done(function () {
+            $('#js_dashboard_Get_allRow_button_' + message_id).prop('disabled', false);
+        }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+            console.log(XMLHttpRequest.status);
+            console.log(textStatus);
+            console.log(errorThrown.message);
+        });
     }
 </script>
 <!-- ここまでデザイン関係なし -->

--- a/resources/views/dashboard/messages.blade.php
+++ b/resources/views/dashboard/messages.blade.php
@@ -33,8 +33,9 @@
                 thread_id: thread_id,
                 message_id: message_id,
             },
-        }).done(function () {
+        }).done(function (data) {
             $('#js_dashboard_Get_allRow_button_' + message_id).prop('disabled', false);
+            $('#js_dashboard_Get_allRow_dev_' + message_id).html(data);
         }).fail(function (XMLHttpRequest, textStatus, errorThrown) {
             console.log(XMLHttpRequest.status);
             console.log(textStatus);

--- a/resources/views/dashboard/messages.blade.php
+++ b/resources/views/dashboard/messages.blade.php
@@ -2,6 +2,7 @@
 <script>
     const table = "{{ $thread_name }}";
     const thread_id = "{{ $thread_id }}";
+    const max_message_id = 0;
 </script>
 
 <script>
@@ -86,6 +87,7 @@
 <!-- ここからデザイン関係なし -->
 <script>
     const url = "{{ url('') }}";
+    show_thread_messages_flag = 1;
 </script>
 <script src="{{ asset('js/app_jquery.js') }}"></script>
 <!-- ここまでデザイン関係なし -->

--- a/resources/views/dashboard/show.blade.php
+++ b/resources/views/dashboard/show.blade.php
@@ -10,6 +10,10 @@
         <h2 class="font-semibold text-xl leading-tight">
             @livewire('dashboard.header')
         </h2>
+
+        <script>
+            var show_thread_messages_flag = 0;
+        </script>
     </x-slot>
     <!-- ここまでカテゴリ別 -->
 


### PR DESCRIPTION
## 関連

- #103 
- #154

## なぜこの変更をするのか

- 通信の負荷軽減

## やったこと

- スレッド書き込み取得を1秒につき1回に変更
- すでに表示されている書き込みから追加された場合のみ追加のデータ（書き込み）取得
- いいねボタンの連打防止

## やらないこと

- #103 
  - 管理者ユーザによる削除・復元が行われていれば全ての書き込みを更新

## できるようになること（ユーザ目線）

- 過去の書き込みが更新されなくなったので，過去の書き込みをコピペのために選択していても更新に伴って選択が解除されるという事が無くなる -> コピペがしやすくなる
- 1度の通信で扱うデータ量が少なくなったので通信量を減らす事が出来る

## できなくなること（ユーザ目線）

- いいねボタン連打によって2以上のいいねカウントを押すことが出来なくなる（正常な動作）

## 動作確認

- 過去の書き込みを選択した状態を更新頻度以上の時間継続出来事を確認
- いいねボタンを連打しても1度しかカウントされない事を確認

## その他

無し