### PR TITLE
週間アクセスランキングの移動

### DIFF
--- a/app/Http/Controllers/dashboard/DashboardController.php
+++ b/app/Http/Controllers/dashboard/DashboardController.php
@@ -8,6 +8,12 @@ use Illuminate\Http\Request;
 
 class DashboardController extends Controller
 {
+    /**
+     * For dashboard thread mode
+     *
+     * @param Request $request
+     * @return Illuminate\Support\Collection
+     */
     public function threads(Request $request)
     {
         return view('dashboard.show', [
@@ -17,6 +23,12 @@ class DashboardController extends Controller
         ]);
     }
 
+    /**
+     * For dashboard messages mode
+     *
+     * @param Request $request
+     * @return Illuminate\Support\Collection
+     */
     public function messages(Request $request)
     {
         return view('dashboard.show', [

--- a/app/Http/Livewire/Dashboard/Header.php
+++ b/app/Http/Livewire/Dashboard/Header.php
@@ -8,9 +8,18 @@ use App\Models\ThreadCategorys;
 
 class Header extends Component
 {
+    /** @var Illuminate\Support\Collection */
     public $categorys;
+
+    /** @var Illuminate\Support\Collection */
     public $category_types;
 
+    /**
+     * Storing data used on this page
+     *
+     * @param Illuminate\Http\Request $request
+     * @return void
+     */
     public function mount(Request $request)
     {
         $this->categorys = ThreadCategorys::get();
@@ -19,6 +28,11 @@ class Header extends Component
             ->get();
     }
 
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
     public function render()
     {
         return view('dashboard.header');

--- a/app/Http/Livewire/Dashboard/Messages.php
+++ b/app/Http/Livewire/Dashboard/Messages.php
@@ -8,19 +8,42 @@ use App\Models\Hub;
 
 class Messages extends Component
 {
-    public function render(Request $request)
+    /** @var string */
+    public $thread_name;
+
+    /** @var string */
+    public $thread_id;
+
+    /** @var int */
+    public $result;
+
+    /**
+     * Storing data used on this page
+     *
+     * @param Illuminate\Http\Request $request
+     * @return void
+     */
+    public function mount(Request $request)
     {
         $exists = Hub::where('thread_id', '=', $request->thread_id)->get();
 
         if ($exists) {
-            $response['result'] = 1;
+            $this->result = 1;
         } else {
-            $response['result'] = 0;
+            $this->result = 0;
         }
 
-        $response['thread_name'] = $request->thread_name;
-        $response['thread_id'] = $request->thread_id;
+        $this->thread_name = $request->thread_name;
+        $this->thread_id = $request->thread_id;
+    }
 
-        return view('dashboard.messages', $response);
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
+    public function render()
+    {
+        return view('dashboard.messages');
     }
 }

--- a/app/Http/Livewire/Dashboard/Rankings.php
+++ b/app/Http/Livewire/Dashboard/Rankings.php
@@ -23,7 +23,6 @@ class Rankings extends Component
      * @param Illuminate\Http\Request $request
      * @return void
      */
-
     public function mount(Request $request)
     {
         $week = Carbon::today()->subDay(7);
@@ -49,7 +48,6 @@ class Rankings extends Component
      *
      * @return Illuminate\Support\Facades\View
      */
-
     public function render()
     {
         return view('dashboard.rankings');

--- a/app/Http/Livewire/Dashboard/Rankings.php
+++ b/app/Http/Livewire/Dashboard/Rankings.php
@@ -26,7 +26,7 @@ class Rankings extends Component
 
     public function mount(Request $request)
     {
-        $week = Carbon::today()->subDay(7);
+        $week = Carbon::today()->subDay(1);
 
         $this->access_ranking = Hub::selectRaw('*, COUNT(*) AS access_count')
             ->rightjoin('access_logs', 'access_logs.thread_id', '=', 'hub.thread_id')
@@ -42,6 +42,9 @@ class Rankings extends Component
             ->groupBy('hub.thread_id')
             ->orderByRaw('COUNT(*) DESC')
             ->get();
+
+        \Illuminate\Support\Facades\Log::debug($this->access_ranking);
+        \Illuminate\Support\Facades\Log::debug($this->weekly_access_ranking);
     }
 
     /**

--- a/app/Http/Livewire/Dashboard/Rankings.php
+++ b/app/Http/Livewire/Dashboard/Rankings.php
@@ -26,7 +26,7 @@ class Rankings extends Component
 
     public function mount(Request $request)
     {
-        $week = Carbon::today()->subDay(1);
+        $week = Carbon::today()->subDay(7);
 
         $this->access_ranking = Hub::selectRaw('*, COUNT(*) AS access_count')
             ->rightjoin('access_logs', 'access_logs.thread_id', '=', 'hub.thread_id')
@@ -42,9 +42,6 @@ class Rankings extends Component
             ->groupBy('hub.thread_id')
             ->orderByRaw('COUNT(*) DESC')
             ->get();
-
-        \Illuminate\Support\Facades\Log::debug($this->access_ranking);
-        \Illuminate\Support\Facades\Log::debug($this->weekly_access_ranking);
     }
 
     /**

--- a/app/Http/Livewire/Dashboard/Rankings.php
+++ b/app/Http/Livewire/Dashboard/Rankings.php
@@ -3,24 +3,54 @@
 namespace App\Http\Livewire\Dashboard;
 
 use Livewire\Component;
-use Illuminate\Http\Request;
+
 use App\Models\Hub;
+use Carbon\Carbon;
+
+use Illuminate\Http\Request;
 
 class Rankings extends Component
 {
+    /** @var Illuminate\Support\Collection */
     public $access_ranking;
+
+    /** @var Illuminate\Support\Collection */
+    public $weekly_access_ranking;
+
+    /**
+     * Storing data used on this page
+     *
+     * @param Illuminate\Http\Request $request
+     * @return void
+     */
 
     public function mount(Request $request)
     {
+        $week = Carbon::today()->subDay(7);
+
         $this->access_ranking = Hub::selectRaw('*, COUNT(*) AS access_count')
             ->rightjoin('access_logs', 'access_logs.thread_id', '=', 'hub.thread_id')
             ->whereNotNull('hub.thread_name')
             ->groupBy('hub.thread_id')
             ->orderByRaw('COUNT(*) DESC')
             ->get();
+
+        $this->weekly_access_ranking = Hub::selectRaw('*, COUNT(*) AS access_count')
+            ->rightjoin('access_logs', 'access_logs.thread_id', '=', 'hub.thread_id')
+            ->whereNotNull('hub.thread_name')
+            ->whereDate('access_logs.created_at', '>=', $week)
+            ->groupBy('hub.thread_id')
+            ->orderByRaw('COUNT(*) DESC')
+            ->get();
     }
 
-    public function render(Request $request)
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
+
+    public function render()
     {
         return view('dashboard.rankings');
     }

--- a/app/Http/Livewire/Dashboard/SelectThreadPages.php
+++ b/app/Http/Livewire/Dashboard/SelectThreadPages.php
@@ -8,18 +8,41 @@ use App\Models\Hub;
 
 class SelectThreadPages extends Component
 {
-    public function render(Request $request)
+    /** @var int */
+    public $max_thread;
+
+    /** @var string */
+    public $sort;
+
+    /** @var string */
+    public $category;
+
+    /**
+     * Storing data used on this page
+     *
+     * @param Illuminate\Http\Request $request
+     * @return void
+     */
+    public function mount(Request $request)
     {
         if ($request->category == NULL) {
-            $RecordNum = Hub::count();
+            $this->max_thread = Hub::count();
         } else {
-            $RecordNum = Hub::where('thread_category', '=', $request->category)
+            $this->max_thread = Hub::where('thread_category', '=', $request->category)
                 ->count();
         }
-        return view('dashboard.select-thread-pages', [
-            'max_thread' => $RecordNum,
-            'sort' => $request->sort,
-            'category' => $request->category
-        ]);
+
+        $this->sort = $request->sort;
+        $this->category = $request->category;
+    }
+
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
+    public function render()
+    {
+        return view('dashboard.select-thread-pages');
     }
 }

--- a/app/Http/Livewire/Dashboard/SendComment.php
+++ b/app/Http/Livewire/Dashboard/SendComment.php
@@ -6,6 +6,11 @@ use Livewire\Component;
 
 class SendComment extends Component
 {
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
     public function render()
     {
         return view('dashboard.send-comment');

--- a/app/Http/Livewire/Dashboard/Threads.php
+++ b/app/Http/Livewire/Dashboard/Threads.php
@@ -9,10 +9,27 @@ use App\Models\Hub;
 
 class Threads extends Component
 {
-    public $threads;
+    /** @var Illuminate\Support\Collection */
+    public $tables;
+
+    /** @var Illuminate\Support\Collection */
     public $categorys;
+
+    /** @var Illuminate\Support\Collection */
     public $category_types;
 
+    /** @var Illuminate\Support\Collection */
+    public $category_name;
+
+    /** @var Illuminate\Support\Collection */
+    public $page;
+
+    /**
+     * Storing data used on this page
+     *
+     * @param Illuminate\Http\Request $request
+     * @return void
+     */
     public function mount(Request $request)
     {
         $category = $request->category;
@@ -20,7 +37,7 @@ class Threads extends Component
 
         if ($category == NULL) {
             if ($sort == 'new_create') {
-                $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
+                $this->tables = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
@@ -28,7 +45,7 @@ class Threads extends Component
                     ->orderByRaw('hub.created_at DESC')
                     ->get();
             } else if ($sort == 'access_count') {
-                $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
+                $this->tables = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
@@ -36,7 +53,7 @@ class Threads extends Component
                     ->orderByRaw('COUNT(access_logs.access_log) DESC')
                     ->get();
             } else {
-                $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
+                $this->tables = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
@@ -45,7 +62,7 @@ class Threads extends Component
             }
         } else {
             if ($sort == 'new_create') {
-                $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
+                $this->tables = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
@@ -54,7 +71,7 @@ class Threads extends Component
                     ->orderByRaw('hub.created_at DESC')
                     ->get();
             } else if ($sort == 'access_count') {
-                $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
+                $this->tables = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
@@ -63,7 +80,7 @@ class Threads extends Component
                     ->orderByRaw('COUNT(access_logs.access_log) DESC')
                     ->get();
             } else {
-                $this->threads = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
+                $this->tables = Hub::selectRaw('hub.*, COALESCE(COUNT(access_logs.access_log), 0) AS Access')
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
@@ -77,14 +94,17 @@ class Threads extends Component
         $this->category_types = ThreadCategorys::select('category_type')
             ->distinct('category_type')
             ->get();
+        $this->category_name = $request->category;
+        $this->page = $request->page;
     }
 
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
     public function render(Request $request)
     {
-        $response['tables'] = $this->threads;
-        $response['category_name'] = $request->category;
-        $response['page'] = $request->page;
-
-        return view('dashboard.threads', $response);
+        return view('dashboard.threads');
     }
 }

--- a/app/Http/Livewire/Dashboard/Various.php
+++ b/app/Http/Livewire/Dashboard/Various.php
@@ -3,22 +3,18 @@
 namespace App\Http\Livewire\Dashboard;
 
 use Livewire\Component;
-use App\Models\Hub;
-use Carbon\Carbon;
 
 class Various extends Component
 {
+
+    /**
+     * Page Display
+     *
+     * @return Illuminate\Support\Facades\View
+     */
+
     public function render()
     {
-        $week = Carbon::today()->subDay(7);
-        $response['week_access_ranking'] = Hub::selectRaw('*, COUNT(*) AS access_count')
-            ->rightjoin('access_logs', 'access_logs.thread_id', '=', 'hub.thread_id')
-            ->whereNotNull('hub.thread_name')
-            ->whereDate('access_logs.created_at', '>=', $week)
-            ->groupBy('hub.thread_id')
-            ->orderByRaw('COUNT(*) DESC')
-            ->get();
-
-        return view('dashboard.various', $response);
+        return view('dashboard.various');
     }
 }

--- a/app/Http/Livewire/Dashboard/Various.php
+++ b/app/Http/Livewire/Dashboard/Various.php
@@ -6,13 +6,11 @@ use Livewire\Component;
 
 class Various extends Component
 {
-
     /**
      * Page Display
      *
      * @return Illuminate\Support\Facades\View
      */
-
     public function render()
     {
         return view('dashboard.various');

--- a/resources/views/dashboard/rankings.blade.php
+++ b/resources/views/dashboard/rankings.blade.php
@@ -3,93 +3,111 @@
  -->
 
 <div class="p-6 border-t border-gray-200 md:border-t-0 md:border-l">
-    <div class="flex items-center">
-        <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
-            class="bi bi-bar-chart-line-fill" viewBox="0 0 16 16">
-            <path
-                d="M11 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h1V7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7h1V2z" />
-        </svg>
-
-        <div class="ml-4 text-lg leading-7 font-semibold">
-            アクセスランキング
-        </div>
-    </div>
-
-    <div class="ml-12">
-        <?php
-        $count = 1;
-        ?>
-        <div class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th>{{ __("Access Ranking") }}</th>
-                        <th>{{ __("Access count") }}</th>
-                        <th>{{__('Thread name')}}</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- スレッド名は「$row['thread_name']」ではなく「$title」 -->
-                    @foreach($access_ranking as $row)
-                    <?php
-                    $title = str_replace("&amp;", "&", $row['thread_name']);
-                    $title = str_replace("&slash;", "/", $title);
-                    $title = str_replace("&backSlash;", "\\", $title);
-                    $title = str_replace("&hash;", "#", $title);
-                    ?>
-                    <tr>
-                        <td>{{ $count++ }}</td>
-                        <td>{{ $row["access_count"] }}</td>
-                        <td>{{ $title }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
-    </div>
-
-    <div class="flex items-center">
-        <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
-            class="bi bi-bar-chart-line-fill" viewBox="0 0 16 16">
-            <path
-                d="M11 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h1V7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7h1V2z" />
-        </svg>
-
-        <div class="ml-4 text-lg leading-7 font-semibold">
-            週間アクセスランキング
-        </div>
-    </div>
-
-    <div class="ml-12">
-        <?php
-        $count = 1;
-        ?>
-        <div class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th>{{ __("Access Ranking") }}</th>
-                        <th>{{ __("Access count") }}</th>
-                        <th>{{__('Thread name')}}</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- スレッド名は「$row['thread_name']」ではなく「$title」 -->
-                    @foreach($weekly_access_ranking as $row)
-                    <?php
-                    $title = str_replace("&amp;", "&", $row['thread_name']);
-                    $title = str_replace("&slash;", "/", $title);
-                    $title = str_replace("&backSlash;", "\\", $title);
-                    $title = str_replace("&hash;", "#", $title);
-                    ?>
-                    <tr>
-                        <td>{{ $count++ }}</td>
-                        <td>{{ $row["access_count"] }}</td>
-                        <td>{{ $title }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
-    </div>
+    <ul class="nav nav-tabs">
+        <li class="nav-item">
+            <a href="#dashboard_rankings_access_ranking" class="nav-link active" data-bs-toggle="tab">アクセスランキング</a>
+        </li>
+        <li class="nav-item">
+            <a href="#dashboard_ranking_weekly_access_ranking" class="nav-link" data-bs-toggle="tab">週間アクセスランキング</a>
+        </li>
+    </ul>
 </div>
+
+
+<dev class="tab-content">
+    <!-- access ranking -->
+    <dev id="dashboard_rankings_access_ranking" class="tab-pane active">
+        <div class="flex items-center">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
+                class="bi bi-bar-chart-line-fill" viewBox="0 0 16 16">
+                <path
+                    d="M11 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h1V7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7h1V2z" />
+            </svg>
+
+            <div class="ml-4 text-lg leading-7 font-semibold">
+                アクセスランキング
+            </div>
+        </div>
+
+        <div class="ml-12">
+            <?php
+            $count = 1;
+            ?>
+            <div class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>{{ __("Access Ranking") }}</th>
+                            <th>{{ __("Access count") }}</th>
+                            <th>{{__('Thread name')}}</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- スレッド名は「$row['thread_name']」ではなく「$title」 -->
+                        @foreach($access_ranking as $row)
+                        <?php
+                        $title = str_replace("&amp;", "&", $row['thread_name']);
+                        $title = str_replace("&slash;", "/", $title);
+                        $title = str_replace("&backSlash;", "\\", $title);
+                        $title = str_replace("&hash;", "#", $title);
+                        ?>
+                        <tr>
+                            <td>{{ $count++ }}</td>
+                            <td>{{ $row["access_count"] }}</td>
+                            <td>{{ $title }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </dev>
+
+    <!-- weekly access ranking -->
+    <dev id="dashboard_rankings_weekly_access_ranking" class="tab-pane">
+        <div class="flex items-center">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
+                class="bi bi-bar-chart-line-fill" viewBox="0 0 16 16">
+                <path
+                    d="M11 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h1V7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7h1V2z" />
+            </svg>
+
+            <div class="ml-4 text-lg leading-7 font-semibold">
+                週間アクセスランキング
+            </div>
+        </div>
+
+        <div class="ml-12">
+            <?php
+            $count = 1;
+            ?>
+            <div class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>{{ __("Access Ranking") }}</th>
+                            <th>{{ __("Access count") }}</th>
+                            <th>{{__('Thread name')}}</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- スレッド名は「$row['thread_name']」ではなく「$title」 -->
+                        @foreach($weekly_access_ranking as $row)
+                        <?php
+                        $title = str_replace("&amp;", "&", $row['thread_name']);
+                        $title = str_replace("&slash;", "/", $title);
+                        $title = str_replace("&backSlash;", "\\", $title);
+                        $title = str_replace("&hash;", "#", $title);
+                        ?>
+                        <tr>
+                            <td>{{ $count++ }}</td>
+                            <td>{{ $row["access_count"] }}</td>
+                            <td>{{ $title }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </dev>
+</dev>

--- a/resources/views/dashboard/rankings.blade.php
+++ b/resources/views/dashboard/rankings.blade.php
@@ -8,7 +8,7 @@
             <a href="#dashboard_rankings_access_ranking" class="nav-link active" data-bs-toggle="tab">アクセスランキング</a>
         </li>
         <li class="nav-item">
-            <a href="#dashboard_ranking_weekly_access_ranking" class="nav-link" data-bs-toggle="tab">週間アクセスランキング</a>
+            <a href="#dashboard_rankings_weekly_access_ranking" class="nav-link" data-bs-toggle="tab">週間アクセスランキング</a>
         </li>
     </ul>
 </div>

--- a/resources/views/dashboard/rankings.blade.php
+++ b/resources/views/dashboard/rankings.blade.php
@@ -47,4 +47,49 @@
             </table>
         </div>
     </div>
+
+    <div class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
+            class="bi bi-bar-chart-line-fill" viewBox="0 0 16 16">
+            <path
+                d="M11 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h1V7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7h1V2z" />
+        </svg>
+
+        <div class="ml-4 text-lg leading-7 font-semibold">
+            週間アクセスランキング
+        </div>
+    </div>
+
+    <div class="ml-12">
+        <?php
+        $count = 1;
+        ?>
+        <div class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>{{ __("Access Ranking") }}</th>
+                        <th>{{ __("Access count") }}</th>
+                        <th>{{__('Thread name')}}</td>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- スレッド名は「$row['thread_name']」ではなく「$title」 -->
+                    @foreach($weekly_access_ranking as $row)
+                    <?php
+                    $title = str_replace("&amp;", "&", $row['thread_name']);
+                    $title = str_replace("&slash;", "/", $title);
+                    $title = str_replace("&backSlash;", "\\", $title);
+                    $title = str_replace("&hash;", "#", $title);
+                    ?>
+                    <tr>
+                        <td>{{ $count++ }}</td>
+                        <td>{{ $row["access_count"] }}</td>
+                        <td>{{ $title }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
 </div>

--- a/resources/views/dashboard/various.blade.php
+++ b/resources/views/dashboard/various.blade.php
@@ -3,48 +3,5 @@
  -->
 
 <div class="p-6 border-t border-gray-200 md:border-t-0 md:border-l">
-    <div class="flex items-center">
-        <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
-            class="bi bi-bar-chart-line-fill" viewBox="0 0 16 16">
-            <path
-                d="M11 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h1V7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7h1V2z" />
-        </svg>
 
-        <div class="ml-4 text-lg leading-7 font-semibold">
-            週間アクセスランキング
-        </div>
-    </div>
-
-    <div class="ml-12">
-        <?php
-        $count = 1;
-        ?>
-        <div class="mt-2 text-gray-600 dark:text-gray-400 text-sm">
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th>{{ __("Access Ranking") }}</th>
-                        <th>{{ __("Access count") }}</th>
-                        <th>{{__('Thread name')}}</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <!-- スレッド名は「$row['thread_name']」ではなく「$title」 -->
-                    @foreach($week_access_ranking as $row)
-                    <?php
-                    $title = str_replace("&amp;", "&", $row['thread_name']);
-                    $title = str_replace("&slash;", "/", $title);
-                    $title = str_replace("&backSlash;", "\\", $title);
-                    $title = str_replace("&hash;", "#", $title);
-                    ?>
-                    <tr>
-                        <td>{{ $count++ }}</td>
-                        <td>{{ $row["access_count"] }}</td>
-                        <td>{{ $title }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
## 関連

- #169 

## なぜこの変更をするのか

無し

## やったこと

- 週間アクセスランキングをランキングモジュールに移動
- アクセスランキングと週間アクセスランキングをタブで切り替え出来る様に

## やらないこと

無し

## できるようになること（ユーザ目線）

- ランキングと週間アクセスランキングをタブで切り替えられる様になる

## できなくなること（ユーザ目線）

- アクセスランキングと週間アクセスランキングを同時に見る事が出来なくなる

## 動作確認

- アクセスランキングと週間アクセスランキングが問題無く表示され，タブで切り替えられる事を確認しました

## その他

次は

- #117 

を行います