### PR TITLE
ログインしていない状態でスレッドにアクセスできるように

### DIFF
--- a/app/Http/Controllers/dashboard/ClubThreadsController.php
+++ b/app/Http/Controllers/dashboard/ClubThreadsController.php
@@ -67,7 +67,7 @@ class ClubThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/CollegeYearThreadsController.php
+++ b/app/Http/Controllers/dashboard/CollegeYearThreadsController.php
@@ -67,7 +67,7 @@ class CollegeYearThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/DashboardController.php
+++ b/app/Http/Controllers/dashboard/DashboardController.php
@@ -12,7 +12,7 @@ class DashboardController extends Controller
      * For dashboard thread mode
      *
      * @param Request $request
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function threads(Request $request)
     {
@@ -27,7 +27,7 @@ class DashboardController extends Controller
      * For dashboard messages mode
      *
      * @param Request $request
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function messages(Request $request)
     {

--- a/app/Http/Controllers/dashboard/DepartmentThreadsController.php
+++ b/app/Http/Controllers/dashboard/DepartmentThreadsController.php
@@ -67,7 +67,7 @@ class DepartmentThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/JobHuntingThreadsController.php
+++ b/app/Http/Controllers/dashboard/JobHuntingThreadsController.php
@@ -67,7 +67,7 @@ class JobHuntingThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/LectureThreadsController.php
+++ b/app/Http/Controllers/dashboard/LectureThreadsController.php
@@ -67,7 +67,7 @@ class LectureThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $user_email, string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/ThreadsController.php
@@ -3,10 +3,12 @@
 namespace App\Http\Controllers\dashboard;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\dashboard\not_logged_in\ThreadsController as NotLoggedInThreadsController;
 
 use App\Models\Hub;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class ThreadsController extends Controller
 {
@@ -90,6 +92,10 @@ class ThreadsController extends Controller
      */
     public function show(Request $request)
     {
+        if (!Auth::check()) {
+            return (new NotLoggedInThreadsController)->show($request->table, $request->max_message_id);
+        }
+
         $thread = Hub::where('thread_id', '=', $request->table)->first();
         switch ($thread->thread_category_type) {
             case '学科':

--- a/app/Http/Controllers/dashboard/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/ThreadsController.php
@@ -87,8 +87,8 @@ class ThreadsController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param Illuminate\Http\Request $request
-     * @return Illuminate\Support\Collection | void
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Support\Collection | void
      */
     public function show(Request $request)
     {

--- a/app/Http/Controllers/dashboard/not_logged_in/ClubThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/ClubThreadsController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\dashboard\not_logged_in;
+
+use App\Http\Controllers\Controller;
+
+use App\Models\ClubThreads;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ClubThreadsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param string $thread_id
+     * @param int $pre_max_message_id
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public function show(string $thread_id, int $pre_max_message_id)
+    {
+        $this->thread_id = $thread_id;
+
+        return ClubThreads::select(
+            'club_threads.*',
+            DB::raw('COUNT(likes1.user_email) AS count_user'),
+            DB::raw('0 AS user_like'),
+            'thread_image_paths.img_path'
+        )
+            ->leftjoin('likes AS likes1', function ($join) {
+                $join
+                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->whereColumn('likes1.message_id', '=', 'club_threads.message_id');
+            })
+            ->leftjoin('thread_image_paths', function ($join) {
+                $join
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'club_threads.thread_id')
+                    ->whereColumn('thread_image_paths.message_id', '=', 'club_threads.message_id');
+            })
+            ->where('club_threads.thread_id', '=', $this->thread_id)
+            ->where('club_threads.message_id', '>', $pre_max_message_id)
+            ->groupBy('club_threads.message_id')
+            ->get();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\ClubThreads  $clubThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(ClubThreads $clubThreads)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\ClubThreads  $clubThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, ClubThreads $clubThreads)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\ClubThreads  $clubThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(ClubThreads $clubThreads)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/dashboard/not_logged_in/ClubThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/ClubThreadsController.php
@@ -48,7 +48,7 @@ class ClubThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/not_logged_in/CollegeYearThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/CollegeYearThreadsController.php
@@ -48,7 +48,7 @@ class CollegeYearThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/not_logged_in/CollegeYearThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/CollegeYearThreadsController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\dashboard\not_logged_in;
+
+use App\Http\Controllers\Controller;
+
+use App\Models\CollegeYearThreads;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class CollegeYearThreadsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param string $thread_id
+     * @param int $pre_max_message_id
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public function show(string $thread_id, int $pre_max_message_id)
+    {
+        $this->thread_id = $thread_id;
+
+        return CollegeYearThreads::select(
+            'college_year_threads.*',
+            DB::raw('COUNT(likes1.user_email) AS count_user'),
+            DB::raw('0 AS user_like'),
+            'thread_image_paths.img_path'
+        )
+            ->leftjoin('likes AS likes1', function ($join) {
+                $join
+                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->whereColumn('likes1.message_id', '=', 'college_year_threads.message_id');
+            })
+            ->leftjoin('thread_image_paths', function ($join) {
+                $join
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'college_year_threads.thread_id')
+                    ->whereColumn('thread_image_paths.message_id', '=', 'college_year_threads.message_id');
+            })
+            ->where('college_year_threads.thread_id', '=', $this->thread_id)
+            ->where('college_year_threads.message_id', '>', $pre_max_message_id)
+            ->groupBy('college_year_threads.message_id')
+            ->get();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\CollegeYearThreads  $collegeYearThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(CollegeYearThreads $collegeYearThreads)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\CollegeYearThreads  $collegeYearThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, CollegeYearThreads $collegeYearThreads)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\CollegeYearThreads  $collegeYearThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(CollegeYearThreads $collegeYearThreads)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/dashboard/not_logged_in/DepartmentThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/DepartmentThreadsController.php
@@ -51,7 +51,7 @@ class DepartmentThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/not_logged_in/DepartmentThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/DepartmentThreadsController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers\dashboard\not_logged_in;
+
+use App\Http\Controllers\Controller;
+
+use App\Models\DepartmentThreads;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class DepartmentThreadsController extends Controller
+{
+    /** @var string */
+    private $thread_id;
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param string $thread_id
+     * @param int $pre_max_message_id
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public function show(string $thread_id, int $pre_max_message_id)
+    {
+        $this->thread_id = $thread_id;
+
+        return DepartmentThreads::select(
+            'department_threads.*',
+            DB::raw('COUNT(likes1.user_email) AS count_user'),
+            DB::raw('0 AS user_like'),
+            'thread_image_paths.img_path'
+        )
+            ->leftjoin('likes AS likes1', function ($join) {
+                $join
+                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->whereColumn('likes1.message_id', '=', 'department_threads.message_id');
+            })
+            ->leftjoin('thread_image_paths', function ($join) {
+                $join
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'department_threads.thread_id')
+                    ->whereColumn('thread_image_paths.message_id', '=', 'department_threads.message_id');
+            })
+            ->where('department_threads.thread_id', '=', $this->thread_id)
+            ->where('department_threads.message_id', '>', $pre_max_message_id)
+            ->groupBy('department_threads.message_id')
+            ->get();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\DepartmentThreads  $departmentThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(DepartmentThreads $departmentThreads)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\DepartmentThreads  $departmentThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, DepartmentThreads $departmentThreads)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\DepartmentThreads  $departmentThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(DepartmentThreads $departmentThreads)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/dashboard/not_logged_in/JobHuntingThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/JobHuntingThreadsController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\dashboard\not_logged_in;
+
+use App\Http\Controllers\Controller;
+
+use App\Models\JobHuntingThreads;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class JobHuntingThreadsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param string $thread_id
+     * @param int $pre_max_message_id
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public function show(string $thread_id, int $pre_max_message_id)
+    {
+        $this->thread_id = $thread_id;
+
+        return JobHuntingThreads::select(
+            'job_hunting_threads.*',
+            DB::raw('COUNT(likes1.user_email) AS count_user'),
+            DB::raw('0 AS user_like'),
+            'thread_image_paths.img_path'
+        )
+            ->leftjoin('likes AS likes1', function ($join) {
+                $join
+                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->whereColumn('likes1.message_id', '=', 'job_hunting_threads.message_id');
+            })
+            ->leftjoin('thread_image_paths', function ($join) {
+                $join
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'job_hunting_threads.thread_id')
+                    ->whereColumn('thread_image_paths.message_id', '=', 'job_hunting_threads.message_id');
+            })
+            ->where('job_hunting_threads.thread_id', '=', $this->thread_id)
+            ->where('job_hunting_threads.message_id', '>', $pre_max_message_id)
+            ->groupBy('job_hunting_threads.message_id')
+            ->get();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\JobHuntingThreads  $jobHuntingThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(JobHuntingThreads $jobHuntingThreads)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\JobHuntingThreads  $jobHuntingThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, JobHuntingThreads $jobHuntingThreads)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\JobHuntingThreads  $jobHuntingThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(JobHuntingThreads $jobHuntingThreads)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/dashboard/not_logged_in/JobHuntingThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/JobHuntingThreadsController.php
@@ -48,7 +48,7 @@ class JobHuntingThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/not_logged_in/LectureThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/LectureThreadsController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\dashboard\not_logged_in;
+
+use App\Http\Controllers\Controller;
+
+use App\Models\LectureThreads;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LectureThreadsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param string $thread_id
+     * @param int $pre_max_message_id
+     *
+     * @return Illuminate\Support\Collection
+     */
+    public function show(string $thread_id, int $pre_max_message_id)
+    {
+        $this->thread_id = $thread_id;
+
+        return LectureThreads::select(
+            'lecture_threads.*',
+            DB::raw('COUNT(likes1.user_email) AS count_user'),
+            DB::raw('0 AS user_like'),
+            'thread_image_paths.img_path'
+        )
+            ->leftjoin('likes AS likes1', function ($join) {
+                $join
+                    ->where('likes1.thread_id', '=', $this->thread_id)
+                    ->whereColumn('likes1.message_id', '=', 'lecture_threads.message_id');
+            })
+            ->leftjoin('thread_image_paths', function ($join) {
+                $join
+                    ->whereColumn('thread_image_paths.thread_id', '=', 'lecture_threads.thread_id')
+                    ->whereColumn('thread_image_paths.message_id', '=', 'lecture_threads.message_id');
+            })
+            ->where('lecture_threads.thread_id', '=', $this->thread_id)
+            ->where('lecture_threads.message_id', '>', $pre_max_message_id)
+            ->groupBy('lecture_threads.message_id')
+            ->get();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\LectureThreads  $lectureThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(LectureThreads $lectureThreads)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\LectureThreads  $lectureThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, LectureThreads $lectureThreads)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\LectureThreads  $lectureThreads
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(LectureThreads $lectureThreads)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/dashboard/not_logged_in/LectureThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/LectureThreadsController.php
@@ -48,7 +48,7 @@ class LectureThreadsController extends Controller
      * @param string $thread_id
      * @param int $pre_max_message_id
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function show(string $thread_id, int $pre_max_message_id)
     {

--- a/app/Http/Controllers/dashboard/not_logged_in/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/ThreadsController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers\dashboard\not_logged_in;
+
+use App\Http\Controllers\Controller;
+use App\Models\Hub;
+use Illuminate\Http\Request;
+
+class ThreadsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param string $thread_id
+     * @param int $pre_max_message_id
+     *
+     * @return \Illuminate\Support\Collection | void
+     */
+    public function show(string $thread_id, int $pre_max_message_id)
+    {
+        $thread = Hub::where('thread_id', '=', $thread_id)->first();
+        switch ($thread->thread_category_type) {
+            case '学科':
+                return (new DepartmentThreadsController)->show($thread_id, $pre_max_message_id);
+            case '学年':
+                return (new CollegeYearThreadsController)->show($thread_id, $pre_max_message_id);
+            case '部活':
+                return (new ClubThreadsController)->show($thread_id, $pre_max_message_id);
+            case '授業':
+                return (new LectureThreadsController)->show($thread_id, $pre_max_message_id);
+            case '就職':
+                return (new JobHuntingThreadsController)->show($thread_id, $pre_max_message_id);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -67,4 +67,24 @@ class Kernel extends HttpKernel
         'Access_log' => \App\Http\Middleware\Access_log::class,
         'Is_Admin' => \App\Http\Middleware\IsAdmin::class,
     ];
+
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * This forces non-global middleware to always be in the given order.
+     *
+     * @var string[]
+     */
+    protected $middlewarePriority = [
+        \App\Http\Middleware\PostAccess_only::class,
+        \Illuminate\Cookie\Middleware\EncryptCookies::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+        \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
+        \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
 }

--- a/app/Http/Livewire/Dashboard/Header.php
+++ b/app/Http/Livewire/Dashboard/Header.php
@@ -8,16 +8,16 @@ use App\Models\ThreadCategorys;
 
 class Header extends Component
 {
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $categorys;
 
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $category_types;
 
     /**
      * Storing data used on this page
      *
-     * @param Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @return void
      */
     public function mount(Request $request)
@@ -31,7 +31,7 @@ class Header extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render()
     {

--- a/app/Http/Livewire/Dashboard/Messages.php
+++ b/app/Http/Livewire/Dashboard/Messages.php
@@ -20,7 +20,7 @@ class Messages extends Component
     /**
      * Storing data used on this page
      *
-     * @param Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @return void
      */
     public function mount(Request $request)
@@ -40,7 +40,7 @@ class Messages extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render()
     {

--- a/app/Http/Livewire/Dashboard/Rankings.php
+++ b/app/Http/Livewire/Dashboard/Rankings.php
@@ -11,16 +11,16 @@ use Illuminate\Http\Request;
 
 class Rankings extends Component
 {
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $access_ranking;
 
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $weekly_access_ranking;
 
     /**
      * Storing data used on this page
      *
-     * @param Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @return void
      */
     public function mount(Request $request)
@@ -46,7 +46,7 @@ class Rankings extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render()
     {

--- a/app/Http/Livewire/Dashboard/SelectThreadPages.php
+++ b/app/Http/Livewire/Dashboard/SelectThreadPages.php
@@ -20,7 +20,7 @@ class SelectThreadPages extends Component
     /**
      * Storing data used on this page
      *
-     * @param Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @return void
      */
     public function mount(Request $request)
@@ -39,7 +39,7 @@ class SelectThreadPages extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render()
     {

--- a/app/Http/Livewire/Dashboard/SendComment.php
+++ b/app/Http/Livewire/Dashboard/SendComment.php
@@ -9,7 +9,7 @@ class SendComment extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render()
     {

--- a/app/Http/Livewire/Dashboard/Threads.php
+++ b/app/Http/Livewire/Dashboard/Threads.php
@@ -9,25 +9,25 @@ use App\Models\Hub;
 
 class Threads extends Component
 {
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $tables;
 
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $categorys;
 
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $category_types;
 
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $category_name;
 
-    /** @var Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     public $page;
 
     /**
      * Storing data used on this page
      *
-     * @param Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @return void
      */
     public function mount(Request $request)
@@ -101,7 +101,7 @@ class Threads extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render(Request $request)
     {

--- a/app/Http/Livewire/Dashboard/Various.php
+++ b/app/Http/Livewire/Dashboard/Various.php
@@ -9,7 +9,7 @@ class Various extends Component
     /**
      * Page Display
      *
-     * @return Illuminate\Support\Facades\View
+     * @return \Illuminate\Support\Facades\View
      */
     public function render()
     {

--- a/app/Http/Middleware/Access_log.php
+++ b/app/Http/Middleware/Access_log.php
@@ -18,7 +18,7 @@ class Access_log
     public function handle(Request $request, Closure $next)
     {
         AccessLogs::create([
-            'user_email' => $request->user()->email,
+            'user_email' => $request->user()->email ?? "Not logged in",
             'thread_name' => $request->thread_name ?? "",
             'thread_id' => $request->thread_id ?? "",
             'access_log' => $request->ip()

--- a/resources/views/dashboard/messages.blade.php
+++ b/resources/views/dashboard/messages.blade.php
@@ -5,6 +5,7 @@
     var max_message_id = 0;
 </script>
 
+@if (Auth::check())
 <script>
     function likes(message_id) {
         var access = "";
@@ -43,6 +44,13 @@
         });
     }
 </script>
+@else
+<script>
+    function likes() {
+        window.location.href = "{{ route('login') }}";
+    }
+</script>
+@endif
 <!-- ここまでデザイン関係なし -->
 
 <!-- ここからスレッドが存在したとき -->

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -44,6 +44,7 @@
 </div>
 
 <!-- ここからデザイン関係なし -->
+@if (Auth::check())
 <script>
     const url = "{{ url('') }}";
 </script>
@@ -54,4 +55,5 @@
     }
 </script>
 <script src="{{ asset('js/app_jquery.js') }}"></script>
+@endif
 <!-- ここまでデザイン関係なし -->

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -2,35 +2,45 @@
     スレッドへ書き込むための部分
  -->
 
-<div class="col-sm-4 col-xs-12">
-    <a class="h4" href="dashboard">トップページへ</a>
-    <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
-        <div class="mb-2">
-            <div class="row">
-                <div class="col-8">
-                    <a id="dashboard_send_comment_reply_source" href="#!">
-                        <input class="form-control" type="text" id="dashboard_send_comment_reply_disabled_text"
-                            disabled>
-                    </a>
+<div class="col-sm-4 col-xs-12 mb-2">
+    <dev class="container row">
+        <a class="h4" href="dashboard">トップページへ</a>
+    </dev>
+    @if (Auth::check())
+    <dev class="container row">
+        <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
+            <div class="mb-2">
+                <div class="row">
+                    <div class="col-8">
+                        <a id="dashboard_send_comment_reply_source" href="#!">
+                            <input class="form-control" type="text" id="dashboard_send_comment_reply_disabled_text"
+                                disabled>
+                        </a>
+                    </div>
+                    <div class="col-4">
+                        <a id="dashboard_send_comment_replay_clear" href="#!">クリア</a>
+                    </div>
                 </div>
-                <div class="col-4">
-                    <a id="dashboard_send_comment_replay_clear" href="#!">クリア</a>
+                <label id="dashboard_send_comment_label" class="form-label">コメント</label>
+                <textarea class="form-control" id="dashboard_message_textarea" rows="4"></textarea>
+                <br />
+                <input type="file" id="dashboard_send_comment_upload_img">
+                <img src="" id="dashboard_send_commnet_img_preview" class="img_preview">
+                <div class="form-text">
+                    入力欄の右下にマウスカーソルを移動させると，高さを変えることができます
                 </div>
+                <div id="dashboard_sendAlertArea"></div>
             </div>
-            <label id="dashboard_send_comment_label" class="form-label">コメント</label>
-            <textarea class="form-control" id="dashboard_message_textarea" rows="4"></textarea>
-            <br />
-            <input type="file" id="dashboard_send_comment_upload_img">
-            <img src="" id="dashboard_send_commnet_img_preview" class="img_preview">
-            <div class="form-text">
-                入力欄の右下にマウスカーソルを移動させると，高さを変えることができます
-            </div>
-            <div id="dashboard_sendAlertArea"></div>
-        </div>
-    </form>
-    <button id="dashboard_sendMessage_btn" class="btn btn-primary">
-        {{ __("Write forum") }}
-    </button>
+        </form>
+        <button id="dashboard_sendMessage_btn" class="btn btn-primary">
+            {{ __("Write forum") }}
+        </button>
+    </dev>
+    @else
+    <dev class="container row">
+        <a href="{{ route('login') }}">スレッドへ書き込む</a>
+    </dev>
+    @endif
 </div>
 
 <!-- ここからデザイン関係なし -->

--- a/resources/views/dashboard/show.blade.php
+++ b/resources/views/dashboard/show.blade.php
@@ -80,7 +80,7 @@
                             ここからTwitterの表示
                             配置のイメージがつかめなかったので応急処置的にここに書いています
                         -->
-                        @if (Auth::user()->thema == 0)
+                        @if (!Auth::check() || Auth::user()->thema == 0)
                         <a class="twitter-timeline" data-chrome="nofooter" data-width="400" data-height="550"
                             data-theme="light" href="https://twitter.com/hxs_?ref_src=twsrc%5Etfw">Tweets by
                             hxs_</a>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,7 +11,7 @@
     <!-- Fonts -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
-    @if (Auth::user()->thema == 0)
+    @if (!Auth::check() || Auth::user()->thema == 0)
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous" />

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -151,7 +151,11 @@
 
                                 <x-jet-dropdown-link href="{{ route('logout') }}" @click.prevent="$root.submit();"
                                     class="text-decoration-none">
+                                    @if (Auth::check())
                                     {{ __('Log Out') }}
+                                    @else
+                                    ウェルカムページへ
+                                    @endif
                                 </x-jet-dropdown-link>
                             </form>
                         </x-slot>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -31,10 +31,16 @@
             <div class="hidden sm:flex sm:items-center sm:ml-6">
                 <!--　ここからがスレット作成ボタン -->
                 <div class="items-center px-3 py-2  ">
+                    @if (Auth::check())
                     <x-jet-danger-button type="button" class="btn btn-danger" data-bs-toggle="modal"
                         data-bs-target="#CreateThread_Modal">
                         {{ __('Create new thread') }}
                         </x-jet-denger-button>
+                        @else
+                        <x-jet-danger-button type="button" class="btn btn-danger" onclick="location.href='/login'">
+                            {{ __('Create new thread') }}
+                            </x-jet-denger-button>
+                            @endif
                 </div>
                 <!-- ここまでがスレット作成ボタン -->
 

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -152,18 +152,23 @@
                             <div class="border-t border-gray-100"></div>
 
                             <!-- Authentication -->
+                            @if (Auth::check())
                             <form method="POST" action="{{ route('logout') }}" x-data>
                                 @csrf
 
                                 <x-jet-dropdown-link href="{{ route('logout') }}" @click.prevent="$root.submit();"
                                     class="text-decoration-none">
-                                    @if (Auth::check())
                                     {{ __('Log Out') }}
-                                    @else
-                                    ウェルカムページへ
-                                    @endif
                                 </x-jet-dropdown-link>
                             </form>
+                            @else
+                            <x-jet-dropdown-link href="{{ route('login') }}" class="text-decoration-none">
+                                {{ __('Log in') }}
+                            </x-jet-dropdown-link>
+                            <x-jet-dropdown-link href="/" class="text-decoration-none">
+                                ウェルカムページへ
+                            </x-jet-dropdown-link>
+                            @endif
                         </x-slot>
                     </x-jet-dropdown>
                 </div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -106,7 +106,11 @@
                             <span class="inline-flex rounded-md">
                                 <button type="button"
                                     class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md hover:text-gray-700 focus:outline-none transition">
+                                    @if (Auth::check())
                                     {{ Auth::user()->name }}
+                                    @else
+                                    未ログイン
+                                    @endif
 
                                     <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg"
                                         viewBox="0 0 20 20" fill="currentColor">
@@ -190,8 +194,20 @@
                 @endif
 
                 <div>
-                    <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                    <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
+                    <div class="font-medium text-base text-gray-800">
+                        @if (Auth::check())
+                        {{ Auth::user()->name }}
+                        @else
+                        未ログイン
+                        @endif
+                    </div>
+                    <div class="font-medium text-sm text-gray-500">
+                        @if (Auth::check())
+                        {{ Auth::user()->email }}
+                        @else
+                        未ログイン
+                        @endif
+                    </div>
                 </div>
             </div>
 

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -165,9 +165,6 @@
                             <x-jet-dropdown-link href="{{ route('login') }}" class="text-decoration-none">
                                 {{ __('Log in') }}
                             </x-jet-dropdown-link>
-                            <x-jet-dropdown-link href="/" class="text-decoration-none">
-                                ウェルカムページへ
-                            </x-jet-dropdown-link>
                             @endif
                         </x-slot>
                     </x-jet-dropdown>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,14 +24,7 @@ Route::middleware([
     config('jetstream.auth_session')
 ])->group(function () {
     Route::get('dashboard', 'App\Http\Controllers\dashboard\DashboardController@threads')->name('dashboard');
-});
 
-// ページ移動（要ログイン）
-Route::middleware([
-    'auth:sanctum',
-    config('jetstream.auth_session'),
-    'verified'
-])->group(function () {
     Route::middleware([
         'Access_log'
     ])->group(function () {
@@ -40,7 +33,14 @@ Route::middleware([
         Route::get('dashboard/thread/name=&id={thread_id}', 'App\Http\Controllers\dashboard\DashboardController@messages');
         Route::get('dashboard/thread/name=&id=', 'App\Http\Controllers\dashboard\DashboardController@messages');
     });
+});
 
+// ページ移動（要ログイン）
+Route::middleware([
+    'auth:sanctum',
+    config('jetstream.auth_session'),
+    'verified'
+])->group(function () {
     Route::get('/mypage', 'App\Http\Controllers\mypage\MyPageController')->name('mypage');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,14 +20,18 @@ Route::get('/', function () {
     config('jetstream.auth_session')
 ]);
 
+Route::middleware([
+    config('jetstream.auth_session')
+])->group(function () {
+    Route::get('dashboard', 'App\Http\Controllers\dashboard\DashboardController@threads')->name('dashboard');
+});
+
 // ページ移動（要ログイン）
 Route::middleware([
     'auth:sanctum',
     config('jetstream.auth_session'),
     'verified'
 ])->group(function () {
-    Route::get('dashboard', 'App\Http\Controllers\dashboard\DashboardController@threads')->name('dashboard');
-
     Route::middleware([
         'Access_log'
     ])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,22 +48,31 @@ Route::middleware([
 Route::middleware([
     'PostAccess_only',
 ])->group(function () {
+    Route::middleware([
+        'auth:sanctum',
+        config('jetstream.auth_session'),
+        'verified'
+    ])->group(function () {
+        Route::controller(\App\Http\Controllers\dashboard\ThreadsController::class)->group(function () {
+            Route::match(['get', 'post'], 'jQuery.ajax/sendRow', 'store');
+        });
+
+        Route::controller(\App\Http\Controllers\dashboard\HubController::class)->group(function () {
+            Route::match(['get', 'post'], 'jQuery.ajax/create_thread', 'store');
+        });
+
+        Route::controller(\App\Http\Controllers\dashboard\LikesController::class)->group(function () {
+            Route::match(['get', 'post'], 'jQuery.ajax/like', 'store');
+            Route::match(['get', 'post'], 'jQuery.ajax/unlike', 'destroy');
+        });
+
+        Route::controller(\App\Http\Controllers\mypage\UsersController::class)->group(function () {
+            Route::match(['get', 'post'], 'jQuery.ajax/page_thema', 'update');
+        });
+    });
+
     Route::controller(\App\Http\Controllers\dashboard\ThreadsController::class)->group(function () {
         Route::match(['get', 'post'], 'jQuery.ajax/getRow', 'show');
-        Route::match(['get', 'post'], 'jQuery.ajax/sendRow', 'store');
-    });
-
-    Route::controller(\App\Http\Controllers\dashboard\HubController::class)->group(function () {
-        Route::match(['get', 'post'], 'jQuery.ajax/create_thread', 'store');
-    });
-
-    Route::controller(\App\Http\Controllers\dashboard\LikesController::class)->group(function () {
-        Route::match(['get', 'post'], 'jQuery.ajax/like', 'store');
-        Route::match(['get', 'post'], 'jQuery.ajax/unlike', 'destroy');
-    });
-
-    Route::controller(\App\Http\Controllers\mypage\UsersController::class)->group(function () {
-        Route::match(['get', 'post'], 'jQuery.ajax/page_thema', 'update');
     });
 });
 

--- a/tests/Feature/dashboard/AuthenticationTest.php
+++ b/tests/Feature/dashboard/AuthenticationTest.php
@@ -25,7 +25,7 @@ class AuthenticationTest extends TestCase
     {
         $response = $this->get('/dashboard');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_user_access()
@@ -50,14 +50,14 @@ class AuthenticationTest extends TestCase
     {
         $response = $this->get('/dashboard?sort=new_create');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_sort0_not_login_access()
     {
         $response = $this->get('/dashboard?sort=');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_sort1_user_access()
@@ -100,14 +100,14 @@ class AuthenticationTest extends TestCase
     {
         $response = $this->get('/dashboard?page=1');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_page0_not_login_access()
     {
         $response = $this->get('/dashboard?page=');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_page1_user_access()
@@ -150,28 +150,28 @@ class AuthenticationTest extends TestCase
     {
         $response = $this->get('/dashboard?page=1&sort=new_create');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_page1_sort0_not_login_access()
     {
         $response = $this->get('/dashboard?page=1&sort=');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_page0_sort1_not_login_access()
     {
         $response = $this->get('/dashboard?page=&sort=new_create');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_page0_sort0_not_login_access()
     {
         $response = $this->get('dashboard?page=&sort=');
 
-        $response->assertRedirect('/login');
+        $response->assertStatus(200);
     }
 
     public function test_dashboard_page1_sort1_user_access()

--- a/tests/Feature/mypage/SelectPageThemaTest.php
+++ b/tests/Feature/mypage/SelectPageThemaTest.php
@@ -52,7 +52,7 @@ class SelectPageThemaTest extends TestCase
             'page_thema' => 0,
         ]);
 
-        $response->assertStatus(500);
+        $response->assertRedirect('/login');
     }
 
     public function test_user_post_access_select_default_page_thema()
@@ -83,7 +83,7 @@ class SelectPageThemaTest extends TestCase
             'page_thema' => 1,
         ]);
 
-        $response->assertStatus(500);
+        $response->assertRedirect('/login');
     }
 
     public function test_user_post_access_select_dark_page_thema()


### PR DESCRIPTION
## 関連

- #87 

## なぜこの変更をするのか

無し

## やったこと

- ログインしていない状態でもダッシュボードに移動できるように
- ログインしていない状態でもスレッドに移動できるように
- ログインしていない状態ではスレッドに書き込みができないように
- ログインしていない状態ではいいね機能を利用できないように
- ログインしていない状態ではスレッドを作成できないように
- ログインしていない状態での動作が変わったのでテストの調整

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- ログインしていない状態でもダッシュボードにアクセスできるようになる
- ログインしていない状態でもスレッドを見ることができるようになる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- ログインした状態での動作が正常なことを確認
- ログインしていない状態でもダッシュボードにアクセスできることを確認
- ログインしていない状態でもスレッドにアクセスできることを確認
- ログインしていない状態ではスレッドに書き込みができないことを確認
- ログインしていない状態ではいいね機能を利用できないことを確認
- ログインしていない状態ではスレッドを作成できないことを確認

## その他

この影響でセキュリティ対策が甘くなっている可能性が十二分にあるため，何か見つければ連絡いただけるとありがたいです．