### PR TITLE
ログイン時にはメール確認済みとなるように変更

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -66,6 +66,7 @@ class Kernel extends HttpKernel
         'PostAccess_only' => \App\Http\Middleware\PostAccess_only::class,
         'Access_log' => \App\Http\Middleware\Access_log::class,
         'Is_Admin' => \App\Http\Middleware\IsAdmin::class,
+        'login.must_verified' => \App\Http\Middleware\MustAuthVerified::class
     ];
 
     /**

--- a/app/Http/Middleware/MustAuthVerified.php
+++ b/app/Http/Middleware/MustAuthVerified.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\URL;
+
+class MustAuthVerified
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  $redirectToRoute
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|null
+     */
+    public function handle($request, Closure $next, $redirectToRoute = null)
+    {
+        if (Auth::check()) {
+            if (
+                !$request->user() ||
+                ($request->user() instanceof MustVerifyEmail &&
+                    !$request->user()->hasVerifiedEmail())
+            ) {
+                return $request->expectsJson()
+                    ? abort(403, 'Your email address is not verified.')
+                    : Redirect::guest(URL::route($redirectToRoute ?: 'verification.notice'));
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/resources/views/dashboard/messages.blade.php
+++ b/resources/views/dashboard/messages.blade.php
@@ -5,7 +5,7 @@
     var max_message_id = 0;
 </script>
 
-@if (Auth::check())
+@if (Auth::check() && Auth::user()->hasVerifiedEmail())
 <script>
     function likes(message_id) {
         var access = "";

--- a/resources/views/dashboard/send-comment.blade.php
+++ b/resources/views/dashboard/send-comment.blade.php
@@ -6,7 +6,7 @@
     <dev class="container row">
         <a class="h4" href="dashboard">トップページへ</a>
     </dev>
-    @if (Auth::check())
+    @if (Auth::check() && Auth::user()->hasVerifiedEmail())
     <dev class="container row">
         <form id="dashboard_sendMessage_form" enctype="multipart/form-data">
             <div class="mb-2">
@@ -44,7 +44,7 @@
 </div>
 
 <!-- ここからデザイン関係なし -->
-@if (Auth::check())
+@if (Auth::check() && Auth::user()->hasVerifiedEmail())
 <script>
     const url = "{{ url('') }}";
 </script>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -31,7 +31,7 @@
             <div class="hidden sm:flex sm:items-center sm:ml-6">
                 <!--　ここからがスレット作成ボタン -->
                 <div class="items-center px-3 py-2  ">
-                    @if (Auth::check())
+                    @if (Auth::check() && Auth::user()->hasVerifiedEmail())
                     <x-jet-danger-button type="button" class="btn btn-danger" data-bs-toggle="modal"
                         data-bs-target="#CreateThread_Modal">
                         {{ __('Create new thread') }}
@@ -112,7 +112,7 @@
                             <span class="inline-flex rounded-md">
                                 <button type="button"
                                     class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md hover:text-gray-700 focus:outline-none transition">
-                                    @if (Auth::check())
+                                    @if (Auth::check() && Auth::user()->hasVerifiedEmail())
                                     {{ Auth::user()->name }}
                                     @else
                                     未ログイン
@@ -152,7 +152,7 @@
                             <div class="border-t border-gray-100"></div>
 
                             <!-- Authentication -->
-                            @if (Auth::check())
+                            @if (Auth::check() && Auth::user()->hasVerifiedEmail())
                             <form method="POST" action="{{ route('logout') }}" x-data>
                                 @csrf
 
@@ -207,14 +207,14 @@
 
                 <div>
                     <div class="font-medium text-base text-gray-800">
-                        @if (Auth::check())
+                        @if (Auth::check() && Auth::user()->hasVerifiedEmail())
                         {{ Auth::user()->name }}
                         @else
                         未ログイン
                         @endif
                     </div>
                     <div class="font-medium text-sm text-gray-500">
-                        @if (Auth::check())
+                        @if (Auth::check() && Auth::user()->hasVerifiedEmail())
                         {{ Auth::user()->email }}
                         @else
                         未ログイン

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,16 +13,14 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// ページ移動
-Route::get('/', function () {
-    return view('welcome');
-})->middleware([
-    config('jetstream.auth_session')
-]);
-
+// ページ移動（ログインせずとも移動可）
 Route::middleware([
-    config('jetstream.auth_session')
+    config('jetstream.auth_session'),
+    'login.must_verified'
 ])->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
     Route::get('dashboard', 'App\Http\Controllers\dashboard\DashboardController@threads')->name('dashboard');
     Route::get('Q_and_A', 'App\Http\Controllers\Q_and_A\Q_and_AController@Q_and_A')->name('Q_and_A');
 


### PR DESCRIPTION
## 関連

- #177 

## なぜこの変更をするのか

- 不具合修正

## やったこと

- ログイン状態かつメール未確認であればメール確認を行うページに移動させるミドルウェアを作成
  - メール確認出来ていなければログイン状態でページを表示させない
- 上記のミドルウェアをダッシュボードページとQ & A ページに適応
- ページ内でログインチェックを行っていた箇所でメール確認済みであるかどうかも条件追加

## やらないこと

なし

## できるようになること（ユーザ目線）

- ログイン時にメール確認が出来ていなければメール確認ページに移動される様になる

## できなくなること（ユーザ目線）

- メール確認なしではログインが出来なくなる

## 動作確認

- ログイン出来ていない状態でもダッシュボードにアクセス出来る事を確認
- 新規登録時にメール確認ページに移動する事を確認
- メール確認出来ていなければログイン状態でもダッシュボードを表示されない事を確認（メール確認ページに移動される）

## その他

無し