### PR TITLE
管理者によるスレッド削除機能

### DIFF
--- a/app/Admin/Controllers/General/ThreadController.php
+++ b/app/Admin/Controllers/General/ThreadController.php
@@ -87,14 +87,14 @@ class ThreadController extends AdminController
         $form->text('thread_name', __('Thread name'));
         $form->textarea('thread_id', __('Thread ID'));
         $form->select('thread_category_type', __('Thread category type'))->options([
-            '学科', '学年', '部活', '授業', '就職'
+            '学科' => '学科', '学年' => '学年', '部活' => '部活', '授業' => '授業', '就職' => '就職'
         ]);
         $form->select('thread_category', __('Thread category'))->options([
-            'IS科', 'IN科', 'IC科', 'ID科', 'IM科',
-            '1年生', '2年生', '3年生', '4年生',
-            'HxSコンピュータ部',
-            'キャリア科目',
-            '2022年度'
+            'IS科' => 'IS科', 'IN科' => 'IN科', 'IC科' => 'IC科', 'ID科' => 'ID科', 'IM科' => 'IN科',
+            '1年生' => '1年生', '2年生' => '2年生', '3年生' => '3年生', '4年生' => '4年生',
+            'HxSコンピュータ部' => 'HxSコンピュータ部',
+            'キャリア科目' => 'キャリア科目',
+            '2022年度' => '2022年度'
         ]);
         $form->email('user_email', __('Email'));
         $form->switch('is_enabled', __('is enabled'))->default(1);

--- a/app/Admin/Controllers/General/ThreadController.php
+++ b/app/Admin/Controllers/General/ThreadController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Admin\Controllers\General;
+
+use App\Models\Hub;
+use Encore\Admin\Controllers\AdminController;
+use Encore\Admin\Form;
+use Encore\Admin\Grid;
+use Encore\Admin\Show;
+
+class ThreadController extends AdminController
+{
+    /**
+     * Title for current resource.
+     *
+     * @var string
+     */
+    protected $title = 'Threads';
+
+    /**
+     * Make a grid builder.
+     *
+     * @return Grid
+     */
+    protected function grid()
+    {
+        $grid = new Grid(new Hub());
+
+        $grid->column('id');
+        $grid->column('thread_name', __('Thread name'));
+        $grid->column('thread_id', __('Thread ID'));
+        $grid->column('thread_category_type', __('Thread category'))
+            ->display(function ($thread_category_type) {
+                return $thread_category_type . ' &rarr; ' . $this->thread_category;
+            });
+        $grid->column('user_email', __('Email'));
+        $grid->column('is_enabled', __('is enabled'))->bool();
+        $grid->column('created_at', __('Created at'));
+        $grid->column('updated_at', __('Updated at'));
+
+        $grid->filter(function ($filter) {
+            $filter->disableIdFilter();
+            $filter->equal('thread_name');
+            $filter->equal('thread_id');
+        });
+
+        return $grid;
+    }
+
+    /**
+     * Make a show builder.
+     *
+     * @param mixed $id
+     * @return Show
+     */
+    protected function detail($id)
+    {
+        $show = new Show(Hub::findOrFail($id));
+        $flags = [
+            0 => 'false',
+            1 => 'true'
+        ];
+
+        $show->field('thread_name', __('Thread name'));
+        $show->field('thread_id', __('Thread ID'));
+        $show->field('thread_category_type', __('Thread category type'));
+        $show->field('thread_category', __('Thread category'));
+        $show->field('user_email', __('Email'));
+        $show->field('is_enabled', __('is enabled'))->as(function ($is_enabled) use ($flags) {
+            return "$flags[$is_enabled]";
+        });
+        $show->field('created_at', __('Created at'));
+        $show->field('updated_at', __('Updated at'));
+
+        return $show;
+    }
+
+    /**
+     * Make a form builder.
+     *
+     * @return Form
+     */
+    protected function form()
+    {
+        $form = new Form(new Hub());
+
+        $form->text('thread_name', __('Thread name'));
+        $form->textarea('thread_id', __('Thread ID'));
+        $form->select('thread_category_type', __('Thread category type'))->options([
+            '学科', '学年', '部活', '授業', '就職'
+        ]);
+        $form->select('thread_category', __('Thread category'))->options([
+            'IS科', 'IN科', 'IC科', 'ID科', 'IM科',
+            '1年生', '2年生', '3年生', '4年生',
+            'HxSコンピュータ部',
+            'キャリア科目',
+            '2022年度'
+        ]);
+        $form->email('user_email', __('Email'));
+        $form->switch('is_enabled', __('is enabled'))->default(1);
+
+        return $form;
+    }
+}

--- a/app/Admin/Extensions/Tools/GeneralUser.php
+++ b/app/Admin/Extensions/Tools/GeneralUser.php
@@ -18,7 +18,7 @@ class GeneralUser extends BatchAction
         return <<<EOT
 
 $('{$this->getElementClass()}').on('click', function() {
-    $('<form/>', {method: 'POST', action: '/admin/users/create/mail'})
+    $('<form/>', {method: 'POST', action: '/admin/general/users/create/mail'})
     .append($('<input/>', {type: 'hidden', name: '_token', value: LA.token}))
     .append($('<input/>', {type: 'hidden', name: 'ids', value: $.admin.grid.selected()}))
     .appendTo(document.body)

--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -1,8 +1,8 @@
 <?php
 
+use Encore\Admin\Facades\Admin;
 use Illuminate\Routing\Router;
-// use Encore\Admin\Facades\Admin;
-// use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Route;
 
 Admin::routes();
 

--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -14,11 +14,11 @@ Route::group([
         $router->get('/', 'index')->name('home');
     });
 
-    $router->resource('/users', General\UserController::class);
+    $router->resource('/general/users', General\UserController::class);
 
     $router->middleware([
         'PostAccess_only'
     ])->group(function (Router $router) {
-        $router->match(['get', 'post'], '/users/create/mail', General\MailController::class);
+        $router->match(['get', 'post'], '/general/users/create/mail', General\MailController::class);
     });
 });

--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Routing\Router;
+// use Encore\Admin\Facades\Admin;
+// use Illuminate\Support\Facades\Route;
 
 Admin::routes();
 
@@ -15,6 +17,7 @@ Route::group([
     });
 
     $router->resource('/general/users', General\UserController::class);
+    $router->resource('/general/threads', General\ThreadController::class);
 
     $router->middleware([
         'PostAccess_only'

--- a/app/Http/Controllers/dashboard/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/ThreadsController.php
@@ -96,7 +96,9 @@ class ThreadsController extends Controller
             return (new NotLoggedInThreadsController)->show($request->table, $request->max_message_id);
         }
 
-        $thread = Hub::where('thread_id', '=', $request->table)->first();
+        $thread = Hub::where('thread_id', '=', $request->table)
+            ->where('is_enabled', '=', 1)
+            ->first();
         switch ($thread->thread_category_type) {
             case '学科':
                 return (new DepartmentThreadsController)->show($request->user()->email, $request->table, $request->max_message_id);

--- a/app/Http/Controllers/dashboard/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/ThreadsController.php
@@ -40,6 +40,8 @@ class ThreadsController extends Controller
      */
     public function store(Request $request)
     {
+        if (Hub::where('thread_id', '=', $request->table)->where('is_enabled', '=', '1')) return;
+
         $special_character_set = array(
             "&" => "&amp;",
             "<" => "&lt;",

--- a/app/Http/Controllers/dashboard/not_logged_in/ThreadsController.php
+++ b/app/Http/Controllers/dashboard/not_logged_in/ThreadsController.php
@@ -49,7 +49,9 @@ class ThreadsController extends Controller
      */
     public function show(string $thread_id, int $pre_max_message_id)
     {
-        $thread = Hub::where('thread_id', '=', $thread_id)->first();
+        $thread = Hub::where('thread_id', '=', $thread_id)
+            ->where('is_enabled', '=', 1)
+            ->first();
         switch ($thread->thread_category_type) {
             case '学科':
                 return (new DepartmentThreadsController)->show($thread_id, $pre_max_message_id);

--- a/app/Http/Livewire/Dashboard/Messages.php
+++ b/app/Http/Livewire/Dashboard/Messages.php
@@ -25,7 +25,9 @@ class Messages extends Component
      */
     public function mount(Request $request)
     {
-        $exists = Hub::where('thread_id', '=', $request->thread_id)->get();
+        $exists = Hub::where('thread_id', '=', $request->thread_id)
+            ->where('is_enabled', '=', 1)
+            ->get();
 
         if ($exists) {
             $this->result = 1;

--- a/app/Http/Livewire/Dashboard/Threads.php
+++ b/app/Http/Livewire/Dashboard/Threads.php
@@ -41,6 +41,7 @@ class Threads extends Component
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
+                    ->where('hub.is_enabled', '=', 1)
                     ->groupBy('hub.thread_id')
                     ->orderByRaw('hub.created_at DESC')
                     ->get();
@@ -49,6 +50,7 @@ class Threads extends Component
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
+                    ->where('hub.is_enabled', '=', 1)
                     ->groupBy('hub.thread_id')
                     ->orderByRaw('COUNT(access_logs.access_log) DESC')
                     ->get();
@@ -57,6 +59,7 @@ class Threads extends Component
                     ->leftJoin('access_logs', function ($join) {
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
+                    ->where('hub.is_enabled', '=', 1)
                     ->groupBy('hub.thread_id')
                     ->get();
             }
@@ -67,6 +70,7 @@ class Threads extends Component
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
                     ->where('hub.thread_category', '=', $category)
+                    ->where('hub.is_enabled', '=', 1)
                     ->groupBy('hub.thread_id')
                     ->orderByRaw('hub.created_at DESC')
                     ->get();
@@ -76,6 +80,7 @@ class Threads extends Component
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
                     ->where('hub.thread_category', '=', $category)
+                    ->where('hub.is_enabled', '=', 1)
                     ->groupBy('hub.thread_id')
                     ->orderByRaw('COUNT(access_logs.access_log) DESC')
                     ->get();
@@ -85,6 +90,7 @@ class Threads extends Component
                         $join->on('hub.thread_id', '=', 'access_logs.thread_id');
                     })
                     ->where('hub.thread_category', '=', $category)
+                    ->where('hub.is_enabled', '=', 1)
                     ->groupBy('hub.thread_id')
                     ->get();
             }

--- a/app/Models/AdminPermissions.php
+++ b/app/Models/AdminPermissions.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AdminPermissions extends Model
+{
+    use HasFactory;
+
+    /**
+     * Database to be connected
+     *
+     * @var string
+     */
+    protected $connection = 'mysql';
+
+
+    /**
+     * Tables to be associated
+     *
+     * @var string
+     */
+    protected $table = 'admin_permissions';
+
+    /**
+     * The attributes that are mass assignable
+     *
+     * @var string[]
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+        'http_method',
+        'http_path'
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => 'datetime:Y-m-d H:i:s',
+        'update_at' => 'datetime:Y-m-d H:i:s',
+    ];
+}

--- a/app/Models/Hub.php
+++ b/app/Models/Hub.php
@@ -34,6 +34,7 @@ class Hub extends Model
         'thread_category',
         'thread_category_type',
         'user_email',
+        'is_enabled'
     ];
 
     /**

--- a/app/Models/Hub.php
+++ b/app/Models/Hub.php
@@ -38,15 +38,6 @@ class Hub extends Model
     ];
 
     /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array
-     */
-    protected $hidden = [
-        'thread_id',
-    ];
-
-    /**
      * The attributes that should be cast.
      *
      * @var array

--- a/database/migrations/2022_08_22_183914_add_is_enabled_to_hub_table.php
+++ b/database/migrations/2022_08_22_183914_add_is_enabled_to_hub_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hub', function (Blueprint $table) {
+            $table->boolean('is_enabled')->default(true)->after('user_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hub', function (Blueprint $table) {
+            $table->dropColumn('is_enabled');
+        });
+    }
+};

--- a/database/seeders/AdminInstallSeeder.php
+++ b/database/seeders/AdminInstallSeeder.php
@@ -26,7 +26,7 @@ class AdminInstallSeeder extends Seeder
             'order' => 9,
             'title' => 'Users',
             'icon' => 'fa-users',
-            'uri' => 'users'
+            'uri' => 'general/users'
         ]);
     }
 }

--- a/database/seeders/AdminMenuSeeder.php
+++ b/database/seeders/AdminMenuSeeder.php
@@ -28,5 +28,13 @@ class AdminMenuSeeder extends Seeder
             'icon' => 'fa-users',
             'uri' => 'general/users'
         ]);
+
+        AdminMenu::updateOrCreate([
+            'parent_id' => 8,
+            'order' => 10,
+            'title' => 'Threads',
+            'icon' => 'fa-book',
+            'uri' => 'general/threads'
+        ]);
     }
 }

--- a/database/seeders/AdminMenuSeeder.php
+++ b/database/seeders/AdminMenuSeeder.php
@@ -5,7 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\AdminMenu;
 
-class AdminInstallSeeder extends Seeder
+class AdminMenuSeeder extends Seeder
 {
     /**
      * Run the database seeds.

--- a/database/seeders/AdminPermissionsSeeder.php
+++ b/database/seeders/AdminPermissionsSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\AdminPermissions;
+
+class AdminPermissionsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        AdminPermissions::updateOrCreate([
+            'name' => 'General users',
+            'slug' => 'general.users',
+            'http_method' => '',
+            'http_path' => '/general/users'
+        ]);
+
+        AdminPermissions::updateOrCreate([
+            'name' => 'Send general users',
+            'slug' => 'general.users.mail',
+            'http_method' => 'GET,POST',
+            'http_path' => '/general/users/create/mail'
+        ]);
+    }
+}

--- a/database/seeders/AdminPermissionsSeeder.php
+++ b/database/seeders/AdminPermissionsSeeder.php
@@ -27,5 +27,12 @@ class AdminPermissionsSeeder extends Seeder
             'http_method' => 'GET,POST',
             'http_path' => '/general/users/create/mail'
         ]);
+
+        AdminPermissions::updateOrCreate([
+            'name' => 'General threads',
+            'slug' => 'general.threads',
+            'http_method' => '',
+            'http_path' => '/general/threads'
+        ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->call(AdminInstallSeeder::class);
+        $this->call(AdminMenuSeeder::class);
+        $this->call(AdminPermissionsSeeder::class);
         $this->call(UserPageThemasSeeder::class);
         $this->call(ThreadCategorysSeeder::class);
     }

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -638,6 +638,10 @@
     "Do you really want to delete it?": "本当に削除しますか？",
     "Do you really want to restore it?": "本当に復元しますか？",
     "Edit thread": "スレッドの編集",
-    "Thread category": "カテゴリー",
-    "Access number": "閲覧回数"
+    "Thread category": "カテゴリ",
+    "Thread category type": "大枠カテゴリ",
+    "Access number": "閲覧回数",
+    "is enabled": "有効",
+    "Created at": "作成日時",
+    "Updated at": "更新日時"
 }


### PR DESCRIPTION
## 関連

- #167 

## なぜこの変更をするのか

無し

## やったこと

- スレッドが有効か無効かを判断するために `hub.is_enabled` を追加
- 無効であればHubに表示しないように
- 向こうであれば有効時と同じURLでアクセスしても閲覧・書き込みをできないように
- 有効・無効を切り替えるための場所をlaravel-adminの `General.Threads` に作成
- laravel-adminの `Admin.Permission` にSeederでレコード追加

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- 管理者画面で有効無効が切り替えられることを確認
- 無効になっていればスレッド一覧に表示されないことを確認
- 無効であればアクセスできないことを確認
- 無効であれば書き込みできないことを確認

## その他

無し